### PR TITLE
tobytes doesn't exist in numpy 1.8 (which appears to be what ubuntu a…

### DIFF
--- a/nengo_spinnaker/regions/matrix.py
+++ b/nengo_spinnaker/regions/matrix.py
@@ -100,4 +100,4 @@ class MatrixRegion(Region):
                 fp.write(struct.pack('I', 1))
 
         # Format the data and then write to file
-        fp.write(data.tobytes())
+        fp.write(data.tostring())


### PR DESCRIPTION
…nd fedora provide in their respective package managers) - replace with confusingly named tostring
