### PR TITLE
Model optimisations

### DIFF
--- a/nengo_spinnaker/builder/builder.py
+++ b/nengo_spinnaker/builder/builder.py
@@ -278,10 +278,12 @@ class Model(object):
         originate from a given intermediate object.
         """
         ports_sigs_conns = collections.defaultdict(
-            lambda: collections.defaultdict(list)
+            lambda: collections.defaultdict(collections_ext.noneignoringlist)
         )
 
-        for (conn, signal) in iteritems(self.connections_signals):
+        for (conn, signal) in itertools.chain(
+                iteritems(self.connections_signals),
+                ((None, s) for s in self.extra_signals)):
             if signal.source.obj is obj:
                 ports_sigs_conns[signal.source.port][signal].append(conn)
 
@@ -292,10 +294,12 @@ class Model(object):
         terminate at a given intermediate object.
         """
         ports_sigs_conns = collections.defaultdict(
-            lambda: collections.defaultdict(list)
+            lambda: collections.defaultdict(collections_ext.noneignoringlist)
         )
 
-        for (conn, signal) in iteritems(self.connections_signals):
+        for (conn, signal) in itertools.chain(
+                iteritems(self.connections_signals),
+                ((None, s) for s in self.extra_signals)):
             for sink in signal.sinks:
                 if sink.obj is obj:
                     ports_sigs_conns[sink.port][signal].append(conn)

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -13,6 +13,7 @@ from .node_io import Ethernet
 from .rc import rc
 from .utils.config import getconfig
 from .utils.machine_control import test_and_boot
+from .utils import model as model_optimisations
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,7 @@ class Simulator(object):
         start_build = time.time()
         self.model = Model(dt, decoder_cache=get_default_decoder_cache())
         self.model.build(network, **builder_kwargs)
+        model_optimisations.remove_childless_filters(self.model)
         logger.info("Build took {:.3f} seconds".format(time.time() -
                                                        start_build))
 

--- a/nengo_spinnaker/utils/model.py
+++ b/nengo_spinnaker/utils/model.py
@@ -39,13 +39,20 @@ def remove_childless_filters(model):
     transmit to at least one other operator. This method will not remove cycles
     of Filters which have no output.
     """
+    # We loop through removing filters that aren't connected to anything so
+    # that we can deal with the case:
+    #
+    #     Filter -> Filter -> Filter -> Filter
+    #
+    # Which should result in the removal of all of the above filters. We break
+    # as soon as there are no more childless filters.
     while True:
         # Childless Filters are those in EITHER the dictionary of object
         # operators or the set of extra operators which have no outgoing
         # signals.
         childless_filters = [
             (k, v) for k, v in
-            itertools.chain(six.iteritems(model.object_operators),
+            itertools.chain(iteritems(model.object_operators),
                             ((None, v) for v in model.extra_operators)) if
             (isinstance(v, Filter) and  # It's a filter
              model.get_signals_connections_from_object(v) == {})  # Unconnected
@@ -55,26 +62,23 @@ def remove_childless_filters(model):
             # If there are no childless filters then we have nothing to do
             break
 
-        # Remove each of the childless filters in turn, this may require us to
-        # remove yet further filters so we go through the loop again.
+        # Remove each of the childless filters in turn.
         for obj, filt in childless_filters:
-            # Generate a list of all connections and signals to remove
-            remove_conns = [
-                (c, s) for c, s in
-                itertools.chain(six.iteritems(model.connections_signals),
-                                ((None, s) for s in model.extra_signals))
-                if filt in [ss.obj for ss in s.sinks]
-            ]
-
-            # Remove all of these connections and signals
-            for conn, sig in remove_conns:
-                if conn is None:
-                    model.extra_signals.remove(sig)
-                else:
-                    model.connections_signals.pop(conn)
+            # Remove the filter from the list of sinks of each of the signals
+            # which target it.
+            for sig in itertools.chain(itervalues(model.connections_signals),
+                                       model.extra_signals):
+                sinks = [s for s in sig.sinks if s.obj is filt]
+                for sink in sinks:
+                    sig.sinks.remove(sink)
 
             # Remove the Filter operator itself
             if obj is None:
                 model.extra_operators.remove(filt)
             else:
                 model.object_operators.pop(obj)
+
+        # Removing filters from the lists of sinks of signals may produce
+        # signals which have no sinks, we should remove these as it will allow
+        # us to find further filters with no children.
+        remove_sinkless_signals(model)

--- a/nengo_spinnaker/utils/model.py
+++ b/nengo_spinnaker/utils/model.py
@@ -3,9 +3,31 @@
 from __future__ import absolute_import
 
 import itertools
-import six
+from six import iteritems, itervalues
 
 from nengo_spinnaker.operators import Filter
+
+
+def remove_sinkless_signals(model):
+    """Remove all Signals which do not have any sinks from a
+    :py:class:`~nengo_spinnaker.builder.Model`.
+    """
+    # Create a list of signals to remove by iterating through the signals which
+    # are related to connections and finding any with no sinks.
+    sinkless_signals = [(c, s) for c, s in iteritems(model.connections_signals)
+                        if len(s.sinks) == 0]
+
+    # Now remove all sinkless signals
+    for conn, sig in sinkless_signals:
+        model.connections_signals.pop(conn)
+
+    # Create a list of signals to remove by finding signals which are not
+    # related to connections and which have no sinks.
+    sinkless_signals = [s for s in model.extra_signals if len(s.sinks) == 0]
+
+    # Now remove all sinkless signals
+    for sig in sinkless_signals:
+        model.extra_signals.remove(sig)
 
 
 def remove_childless_filters(model):

--- a/nengo_spinnaker/utils/model.py
+++ b/nengo_spinnaker/utils/model.py
@@ -1,5 +1,7 @@
 """Model Optimisations
 """
+from __future__ import absolute_import
+
 import itertools
 import six
 

--- a/nengo_spinnaker/utils/model.py
+++ b/nengo_spinnaker/utils/model.py
@@ -1,0 +1,56 @@
+"""Model Optimisations
+"""
+import itertools
+import six
+
+from nengo_spinnaker.operators import Filter
+
+
+def remove_childless_filters(model):
+    """Remove all Filter operators which do not transmit to anything from a
+    :py:class:`~nengo_spinnaker.builder.Model`.
+
+    Transmitting values to a filter which then doesn't forward them is a waste
+    of network bandwidth. This method optimises out all filters which do not
+    transmit to at least one other operator. This method will not remove cycles
+    of Filters which have no output.
+    """
+    while True:
+        # Childless Filters are those in EITHER the dictionary of object
+        # operators or the set of extra operators which have no outgoing
+        # signals.
+        childless_filters = [
+            (k, v) for k, v in
+            itertools.chain(six.iteritems(model.object_operators),
+                            ((None, v) for v in model.extra_operators)) if
+            (isinstance(v, Filter) and  # It's a filter
+             model.get_signals_connections_from_object(v) == {})  # Unconnected
+        ]
+
+        if not childless_filters:
+            # If there are no childless filters then we have nothing to do
+            break
+
+        # Remove each of the childless filters in turn, this may require us to
+        # remove yet further filters so we go through the loop again.
+        for obj, filt in childless_filters:
+            # Generate a list of all connections and signals to remove
+            remove_conns = [
+                (c, s) for c, s in
+                itertools.chain(six.iteritems(model.connections_signals),
+                                ((None, s) for s in model.extra_signals))
+                if filt in [ss.obj for ss in s.sinks]
+            ]
+
+            # Remove all of these connections and signals
+            for conn, sig in remove_conns:
+                if conn is None:
+                    model.extra_signals.remove(sig)
+                else:
+                    model.connections_signals.pop(conn)
+
+            # Remove the Filter operator itself
+            if obj is None:
+                model.extra_operators.remove(filt)
+            else:
+                model.object_operators.pop(obj)

--- a/tests/builder/test_builder.py
+++ b/tests/builder/test_builder.py
@@ -642,6 +642,13 @@ class TestGetSignalsAndConnections(object):
                          ObjectPort(obj_b, InputPort.standard),
                          None)
 
+        sig_ab3 = Signal(ObjectPort(obj_a, OutputPort.standard),
+                         ObjectPort(obj_b, InputPort.standard),
+                         None)
+        sig_ab4 = Signal(ObjectPort(obj_a, OutputPort.standard),
+                         ObjectPort(obj_b, InputPort.standard),
+                         None)
+
         conn_ba1 = mock.Mock()
         port_b1 = mock.Mock(name="port B1")
         sig_ba1 = Signal(ObjectPort(obj_b, port_b1),
@@ -654,6 +661,11 @@ class TestGetSignalsAndConnections(object):
                          ObjectPort(obj_a, InputPort.standard),
                          None)
 
+        port_b3 = mock.Mock(name="port B3")
+        sig_ba3 = Signal(ObjectPort(obj_b, port_b3),
+                         ObjectPort(obj_a, InputPort.standard),
+                         None)
+
         # Create a model holding all of these items
         model = Model()
         model.connections_signals = {
@@ -663,12 +675,15 @@ class TestGetSignalsAndConnections(object):
             conn_ba2: sig_ba2,
             conn_ba3: sig_ba2,
         }
+        model.extra_signals = [sig_ab3, sig_ab4, sig_ba3]
 
         # Query it for connections starting from different objects
         assert model.get_signals_connections_from_object(obj_a) == {
             OutputPort.standard: {
                 sig_ab1: [conn_ab1],
                 sig_ab2: [conn_ab2],
+                sig_ab3: [],
+                sig_ab4: [],
             },
         }
 
@@ -683,6 +698,8 @@ class TestGetSignalsAndConnections(object):
                     assert sig is sig_ba2
                     for conn in conns:
                         assert conn is conn_ba2 or conn is conn_ba3
+            elif port is port_b3:
+                assert sigs_conns == {sig_ba3: []}
             else:
                 assert False, "Unexpected signal"
 
@@ -705,6 +722,10 @@ class TestGetSignalsAndConnections(object):
                          ObjectPort(obj_b, port_b2),
                          None)
 
+        sig_ab3 = Signal(ObjectPort(obj_a, OutputPort.standard),
+                         ObjectPort(obj_b, port_b2),
+                         None)
+
         conn_ba1 = mock.Mock()
         sig_ba1 = Signal(ObjectPort(obj_b, OutputPort.standard),
                          ObjectPort(obj_a, InputPort.standard),
@@ -724,6 +745,7 @@ class TestGetSignalsAndConnections(object):
             conn_ba2: sig_ba2,
             conn_ba3: sig_ba2,
         }
+        model.extra_signals = [sig_ab3]
 
         # Query it for connections terminating at different objects
         for port, sigs_conns in iteritems(
@@ -736,6 +758,8 @@ class TestGetSignalsAndConnections(object):
                 elif sig is sig_ba2:
                     for conn in conns:
                         assert conn in [conn_ba2, conn_ba3]
+                elif sig is sig_ba3:
+                    assert len(conns) == 0
                 else:
                     assert False, "Unexpected signal"
 
@@ -745,6 +769,7 @@ class TestGetSignalsAndConnections(object):
             },
             port_b2: {
                 sig_ab2: [conn_ab2],
+                sig_ab3: [],
             },
         }
 

--- a/tests/utils/test_utils_model.py
+++ b/tests/utils/test_utils_model.py
@@ -2,7 +2,39 @@ import mock
 
 from nengo_spinnaker.builder.builder import Model, ObjectPort, Signal
 from nengo_spinnaker.operators import Filter
-from nengo_spinnaker.utils.model import remove_childless_filters
+from nengo_spinnaker.utils.model import (remove_childless_filters,
+                                         remove_sinkless_signals)
+
+
+def test_remove_sinkless_signals():
+    """Signals with no sink should be removed."""
+    # Create a netlist including some signals with no sinks, these signals
+    # should be removed.
+    o1 = mock.Mock(name="O1")
+    o2 = mock.Mock(name="O2")
+
+    # Create 4 signals (2 associated with connections, 2 not)
+    cs1 = Signal(ObjectPort(o1, None), ObjectPort(o2, None), None)
+    cs2 = Signal(ObjectPort(o1, None), [], None)
+    ss1 = Signal(ObjectPort(o1, None), ObjectPort(o2, None), None)
+    ss2 = Signal(ObjectPort(o1, None), [], None)
+
+    # Create two mock connections
+    c1 = mock.Mock(name="Connection 1")
+    c2 = mock.Mock(name="Connection 2")
+
+    # Create the model
+    model = Model()
+    model.extra_operators = [o1, o2]
+    model.connections_signals = {c1: cs1, c2: cs2}
+    model.extra_signals = [ss1, ss2]
+
+    # Remove sinkless signals
+    remove_sinkless_signals(model)
+
+    # Check that signals were removed as necessary
+    assert model.connections_signals == {c1: cs1}
+    assert model.extra_signals == [ss1]
 
 
 def test_remove_childless_filters():

--- a/tests/utils/test_utils_model.py
+++ b/tests/utils/test_utils_model.py
@@ -1,0 +1,73 @@
+import mock
+
+from nengo_spinnaker.builder.builder import Model, ObjectPort, Signal
+from nengo_spinnaker.operators import Filter
+from nengo_spinnaker.utils.model import remove_childless_filters
+
+
+def test_remove_childless_filters():
+    """Filter operators which don't transmit to anything, and their incoming
+    signals, can be removed.
+    """
+    # Create a netlist including some filters that do and don't transmit to
+    # other objects, check that all the filters which don't connect to anything
+    # are removed.
+    #
+    #          -S1---             F3
+    #        /       \       S4  ^  \  S5
+    #       /        v          /    v
+    #     F1         O1 -S3-> F2     F5
+    #      ^        /          \     ^
+    #      \       /        S4  v   /  S6
+    #       \-S2---              F4
+    #
+    # F1 should remain, 01 should be untouched and F2..5 should be removed.
+
+    # Create the filter operators
+    f1 = Filter(1)
+    f2 = Filter(1)
+    f3 = Filter(1)
+    f4 = Filter(1)
+    f5 = Filter(1)
+
+    # The other operator
+    o1 = mock.Mock()
+
+    # Create some objects which map to some of the operators
+    oo1 = mock.Mock()
+    of3 = mock.Mock()
+
+    # Create the signals
+    s1 = Signal(ObjectPort(f1, None), ObjectPort(o1, None), None)
+    s2 = Signal(ObjectPort(o1, None), ObjectPort(f1, None), None)
+    s3 = Signal(ObjectPort(o1, None), ObjectPort(f2, None), None)
+    s4 = Signal(ObjectPort(f2, None), [ObjectPort(f3, None),
+                                       ObjectPort(f4, None)], None)
+    s5 = Signal(ObjectPort(f3, None), ObjectPort(f5, None), None)
+    s6 = Signal(ObjectPort(f4, None), ObjectPort(f5, None), None)
+
+    # Create some connections which map to the signals
+    cs4 = mock.Mock()
+    cs5 = mock.Mock()
+
+    # Create the model
+    model = Model()
+    model.object_operators = {
+        oo1: o1,
+        of3: f3,
+    }
+    model.extra_operators = [f1, f2, f4, f5]
+    model.connections_signals = {
+        cs4: s4,
+        cs5: s5,
+    }
+    model.extra_signals = [s1, s2, s3, s6]
+
+    # Perform the optimisation
+    remove_childless_filters(model)
+
+    # Check that objects have been removed
+    assert model.object_operators == {oo1: o1}
+    assert model.extra_operators == [f1]
+    assert model.connections_signals == {}
+    assert model.extra_signals == [s1, s2]


### PR DESCRIPTION
This fixes the model so that it correctly reports signals which are not associated with connections.  More importantly it adds the ability to remove from the model any filter operators (e.g., instantiations of passthrough nodes) which don't transmit packets to anything; this reduces the number of packets transmitted by anything which feeds into them.
