### PR TITLE
Fix config file path for Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ either the directory you will be running your code from or, more usefully, a
 centralised location. The centralised location varies based on your operating
 system:
 
-- Windows: ``%userprofile%\nengo\nengo_spinnaker.conf``
+- Windows: ``%userprofile%\.nengo\nengo_spinnaker.conf``
 - Other: ``~/.config/nengo/nengo_spinnaker.conf``
 
 This file exists to inform ``nengo_spinnaker`` of the nature of the SpiNNaker

--- a/nengo_spinnaker-data/nengo_spinnaker.conf
+++ b/nengo_spinnaker-data/nengo_spinnaker.conf
@@ -7,7 +7,7 @@
 # 1. An operating system specific file in the user's home directory.  This is
 #    the recommended location to place configuration options, unless you intend
 #    to use multiple different SpiNNaker machines in rapid succession.
-#      - Windows: %userprofile%\nengo\nengo_spinnaker.conf
+#      - Windows: %userprofile%\.nengo\nengo_spinnaker.conf
 #      - Other: ~/.config/nengo/nengo_spinnaker.conf
 # 2. nengo_spinnaker.conf in the current working directory.
 #    This is probably the best location for those working with many different


### PR DESCRIPTION
This was incorrectly reported in the README and the config file itself.

Fixes #15
