### PR TITLE
Fix typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ For example::
     with model:
         signal = nengo.Node(lambda t: np.sin(t))
 
-    nengo_spinnaker.add_params(model.config)
+    nengo_spinnaker.add_spinnaker_params(model.config)
     model.config[signal].function_of_time = True
 
 


### PR DESCRIPTION
README referred to `add_params`, this should have been
`add_spinnaker_params`
