### PR TITLE
Remove passthrough Nodes at the signal level

### DIFF
--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -93,6 +93,7 @@ class Simulator(object):
         self.model = Model(dt, decoder_cache=get_default_decoder_cache())
         self.model.build(network, **builder_kwargs)
         model_optimisations.remove_childless_filters(self.model)
+        model_optimisations.remove_passthrough_nodes(self.model)
         logger.info("Build took {:.3f} seconds".format(time.time() -
                                                        start_build))
 

--- a/tests/utils/test_utils_model.py
+++ b/tests/utils/test_utils_model.py
@@ -1,9 +1,15 @@
 import mock
+import nengo
+import pytest
+from six import iteritems
 
-from nengo_spinnaker.builder.builder import Model, ObjectPort, Signal
+from nengo_spinnaker.builder.builder import (Model, ObjectPort, Signal,
+                                             InputPort)
 from nengo_spinnaker.operators import Filter
 from nengo_spinnaker.utils.model import (remove_childless_filters,
-                                         remove_sinkless_signals)
+                                         remove_sinkless_signals,
+                                         remove_passthrough_nodes)
+import nengo_spinnaker
 
 
 def test_remove_sinkless_signals():
@@ -109,3 +115,162 @@ def test_remove_childless_filters():
     assert model.connections_signals == {}
     assert model.extra_signals == [s1, s2, s3]
     assert [s.obj for s in s3.sinks] == [o2]
+
+
+def test_remove_passnodes():
+    """Test that passnodes can be correctly removed from a network.
+
+    We create and build the following model and then ensure that the pass node
+    is removed related connections are moved as required.
+
+        E1 -->\    /---> E5
+               \  /
+        E2 -->\    /---> E6
+                PN
+        E3 -->/  | \---> E7
+               / |\
+        E4 -->/  | \---> E8
+                 \
+                  \----> P1
+
+    Should become:
+
+        E1 -+----------> E5
+             \
+        E2 ---+--------> E6
+              \
+        E3 ----+-------> E7
+                \
+        E4 ------+-----> E8
+                  \
+                   \---> P1
+    """
+    # Create the Nengo model
+    with nengo.Network() as network:
+        # Create the Ensembles
+        e1_4 = [nengo.Ensemble(100, 1) for _ in range(4)]
+        e5_8 = [nengo.Ensemble(100, 1) for _ in range(4)]
+
+        # Add the passnode
+        pn = nengo.Node(size_in=4)
+
+        # And the probe
+        p1 = nengo.Probe(pn)
+
+        # Finally, add the connections
+        connections = list()
+        connections.extend(nengo.Connection(e1_4[n], pn[n], synapse=None) for
+                           n in range(4))
+        connections.extend(nengo.Connection(pn[n], e5_8[n], synapse=None) for
+                           n in range(4))
+
+    # Build this into a model
+    nioc = nengo_spinnaker.builder.node.NodeIOController()
+    model = Model()
+    model.build(network, **nioc.builder_kwargs)
+
+    # Apply the passnode remover to the model
+    remove_passthrough_nodes(model)
+
+    # Check that this was indeed done...
+    # None of the original connections should be in the model
+    # connections->signals mapping, but they should remain in the parameters
+    # dictionary.
+    for conn in connections:
+        assert conn not in model.connections_signals
+        assert conn in model.params
+
+    # E5..8 should have one input each, this should be a signal from their
+    # partner in E1..4 and should be paired with a signal with an appropriate
+    # transform.  The signal should be of weight 1.
+    for i, ens in enumerate(e5_8):
+        # Get the object simulating the ensemble
+        lif = model.object_operators[ens]
+
+        # Check the incoming signals
+        sigs = model.get_signals_connections_to_object(lif)[InputPort.standard]
+        assert len(sigs) == 1
+
+        for sig, conns in iteritems(sigs):
+            # Check the connection is sane
+            assert len(conns) == 1
+            conn = conns[0]
+            assert conn.pre_obj is e1_4[i]
+
+            # Check that the signal is sane
+            assert sig.weight == 1
+            assert sig.source.obj is model.object_operators[e1_4[i]]
+
+    # P1 should receive many signals, one per pre-ensemble, and these should be
+    # associated with similar connections.
+    probe_op = model.object_operators[p1]
+    sigs =\
+        model.get_signals_connections_to_object(probe_op)[InputPort.standard]
+    assert len(sigs) == 4
+    for sig, conns in iteritems(sigs):
+        # Check the connection is sane
+        assert len(conns) == 1
+        conn = conns[0]
+        assert conn.pre_obj in e1_4
+
+        # Check that the signal is sane
+        # assert sig.weight == 1
+        assert sig.source.obj is model.object_operators[conn.pre_obj]
+
+
+@pytest.mark.parametrize("signal_in", ["input", "output"])
+def test_remove_passthrough_nodes_aborts_multisink(signal_in):
+    """Check that removing passthrough Nodes does nothing in the case that
+    there is an input signal with multiple sinks.
+    """
+    # Create a Nengo model
+    with nengo.Network() as network:
+        a = nengo.Ensemble(500, 5)
+        b = nengo.Node(size_in=5)
+        c = nengo.Ensemble(100, 5)
+
+        a_b = nengo.Connection(a, b)
+        b_c = nengo.Connection(b, c)
+
+    # Build this into a model
+    nioc = nengo_spinnaker.builder.node.NodeIOController()
+    model = Model()
+    model.build(network, **nioc.builder_kwargs)
+
+    if signal_in == "input":
+        # Add an extra sink to the signal associated with a->b
+        model.connections_signals[a_b].sinks.append(ObjectPort(None, None))
+    else:
+        # Add an extra sink to the signal associated with b->c
+        model.connections_signals[b_c].sinks.append(ObjectPort(None, None))
+
+    # Check that removing passthrough Nodes does nothing
+    remove_passthrough_nodes(model)
+    assert b in model.object_operators
+    assert a_b in model.connections_signals
+    assert b_c in model.connections_signals
+
+
+def test_remove_passthrough_nodes_aborts_merge_filters():
+    """Check that removing passthrough Nodes does nothing in the case that
+    there is a synapse on both the incoming and the outgoing connection.
+    """
+    # Create a Nengo model
+    with nengo.Network() as network:
+        a = nengo.Ensemble(500, 5)
+        b = nengo.Node(size_in=5)
+        c = nengo.Ensemble(100, 5)
+
+        a_b = nengo.Connection(a, b, synapse=0.005)
+        b_c = nengo.Connection(b, c, synapse=0.001)
+
+    # Build this into a model
+    nioc = nengo_spinnaker.builder.node.NodeIOController()
+    model = Model()
+    model.build(network, **nioc.builder_kwargs)
+
+    # Check that removing passthrough Nodes does nothing
+    remove_passthrough_nodes(model)
+    assert b in model.object_operators
+    assert a_b in model.connections_signals
+    assert b_c in model.connections_signals


### PR DESCRIPTION
Passthrough Nodes are becoming a nuisance because they cause significant fan-ins in models.  This PR removes passthrough Nodes wherever possible.
- [ ] Get a signal to send to two sinks if this would have been the effect of the passthrough Node.
- [ ] Split Probes which probe passthrough Nodes to reduce fan-in (maybe for a later PR)
