### PR TITLE
Nodes to global inhibition

### DIFF
--- a/nengo_spinnaker/builder/connection.py
+++ b/nengo_spinnaker/builder/connection.py
@@ -22,7 +22,7 @@ def generic_sink_getter(model, conn):
 def build_generic_connection_params(model, conn):
     return BuiltConnection(
         decoders=None,
-        transform=full_transform(conn, slice_pre=False),
+        transform=full_transform(conn, slice_pre=False, allow_scalars=False),
         eval_points=None,
         solver_info=None
     )

--- a/nengo_spinnaker/builder/node.py
+++ b/nengo_spinnaker/builder/node.py
@@ -232,9 +232,9 @@ class NodeIOController(object):
         """
         raise NotImplementedError
 
-    def prepare(self, controller, netlist):
-        """Prepare the Node controller to work with the given netlist and
-        machine controller.
+    def prepare(self, model, controller, netlist):
+        """Prepare the Node controller to work with the given model, netlist
+        and machine controller.
         """
         pass
 

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -110,7 +110,7 @@ class Simulator(object):
 
         # Prepare the simulator against the placed, allocated and routed
         # netlist.
-        self.io_controller.prepare(self.controller, self.netlist)
+        self.io_controller.prepare(self.model, self.controller, self.netlist)
 
         # Load the application
         logger.info("Loading application")

--- a/regression-tests/test_global_inhibition.py
+++ b/regression-tests/test_global_inhibition.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.parametrize("source", ("ensemble", "f_of_t_node"))
+@pytest.mark.parametrize("source", ("ensemble", "node", "f_of_t_node"))
 def test_global_inhibition(source):
     with nengo.Network("Test Network") as network:
         # Create a 2-d ensemble representing a constant value
@@ -28,9 +28,10 @@ def test_global_inhibition(source):
             nengo.Connection(gate_control, ens.neurons,
                              transform=[[-10.0]] * ens.n_neurons)
 
-    # Mark appropriate Nodes as functions of time
-    nengo_spinnaker.add_spinnaker_params(network.config)
-    network.config[gate_control].function_of_time = True
+    # Mark appropriate Nodes as functions of time if desired
+    if source != "node":
+        nengo_spinnaker.add_spinnaker_params(network.config)
+        network.config[gate_control].function_of_time = True
 
     # Create the simulate and simulate
     sim = nengo_spinnaker.Simulator(network)
@@ -41,9 +42,9 @@ def test_global_inhibition(source):
         sim.run(2.0)
 
     # Check that the values are decoded as expected
-    index10 = int(p_ens.synapse.tau * 3 / sim.dt)
+    index10 = int(p_ens.synapse.tau * 4 / sim.dt)
     index11 = 1.0 / sim.dt
-    index20 = index11 + int(p_ens.synapse.tau * 3 / sim.dt)
+    index20 = index11 + int(p_ens.synapse.tau * 4 / sim.dt)
     data = sim.data[p_ens]
 
     assert (np.all(+0.20 <= data[index10:index11, 0]) and
@@ -58,4 +59,5 @@ def test_global_inhibition(source):
 
 if __name__ == "__main__":
     test_global_inhibition("ensemble")
+    test_global_inhibition("node")
     test_global_inhibition("f_of_t_node")

--- a/tests/builder/test_node.py
+++ b/tests/builder/test_node.py
@@ -26,11 +26,12 @@ class TestNodeIOController(object):
 
     def test_prepare(self):
         """Preparing the default NodeIOController does nothing."""
+        model = mock.Mock()
         controller = mock.Mock(spec_set=[])
         netlist = mock.Mock(spec_set=[])
 
         nioc = NodeIOController()
-        nioc.prepare(controller, netlist)
+        nioc.prepare(model, controller, netlist)
 
     def test_close(self):
         """Closing the default NodeIOController does nothing."""

--- a/tests/operators/test_sdp_receiver.py
+++ b/tests/operators/test_sdp_receiver.py
@@ -1,4 +1,5 @@
 import mock
+import numpy as np
 import pytest
 from rig.machine import Cores, SDRAM
 import six
@@ -47,6 +48,10 @@ class TestSDPReceiver(object):
             conn_a: sig_a,
             conn_b: sig_b,
         }
+        model.params[conn_a] = mock.Mock()
+        model.params[conn_a].transform = np.eye(conn_a.size_out)
+        model.params[conn_b] = mock.Mock()
+        model.params[conn_b].transform = np.eye(conn_b.size_out)
 
         # Make the vertices
         nls = sdp_rx.make_vertices(model, 1)  # TODO Remove number of steps


### PR DESCRIPTION
This should fix models of the type:

``` python
with nengo.Network() as model:
    gate = nengo.Node(..., size_in=0, size_out=x)  # NOT A PASSTHROUGH NODE
    ens = nengo.Ensemble(...)
    nengo.Connection(gate, ens, transform=[[-xxx]]*ens.n_neurons)
```

Regardless of whether `gate` is a function of time Node or not.

This fixes #21.  This does not fix connections from passthrough nodes to neurons.

@celiasmith / @tcstewar can you confirm that this works for you please?  I've just tested this in the GUI and it works for me.
