### PR TITLE
Constant valued Nodes and precomputation

### DIFF
--- a/nengo_spinnaker/builder/node.py
+++ b/nengo_spinnaker/builder/node.py
@@ -108,12 +108,16 @@ class NodeIOController(object):
             model.object_operators[node] = op
         elif f_of_t:
             # If the Node is a function of time then add a new value source for
-            # it.
-            vs = ValueSource(
-                node.output,
-                node.size_out,
-                getconfig(model.config, node, "function_of_time_period")
-            )
+            # it.  Determine the period by looking in the config, if the output
+            # is a constant then the period is dt (i.e., it repeats every
+            # timestep).
+            if not callable(node.output):
+                period = model.dt
+            else:
+                period = getconfig(model.config, node,
+                                   "function_of_time_period")
+
+            vs = ValueSource(node.output, node.size_out, period)
             self._f_of_t_nodes[node] = vs
             model.object_operators[node] = vs
         else:

--- a/regression-tests/test_f_of_t_node.py
+++ b/regression-tests/test_f_of_t_node.py
@@ -44,5 +44,24 @@ def test_function_of_time_node():
             np.all(-0.48 <= data[index20:, 0]))
 
 
+def test_constant_node():
+    with nengo.Network("Test Network") as model:
+        in_val = nengo.Node([0.5])
+        pn = nengo.Node(size_in=1)
+        ens = nengo.Ensemble(100, 1)
+
+        nengo.Connection(in_val, pn)
+        nengo.Connection(pn, ens)
+
+        probe = nengo.Probe(ens, synapse=0.05)
+
+    sim = nengo_spinnaker.Simulator(model)
+    with sim:
+        sim.run(0.5)
+
+    assert 0.45 < sim.data[probe][-1] < 0.55
+
+
 if __name__ == "__main__":
     test_function_of_time_node()
+    test_constant_node()

--- a/tests/builder/test_node.py
+++ b/tests/builder/test_node.py
@@ -114,7 +114,7 @@ class TestNodeIOController(object):
 
         # Assert that this added a new operator to the model
         assert model.object_operators[a].function is a.output
-        assert model.object_operators[a].period is None
+        assert model.object_operators[a].period is model.dt
 
         assert model.extra_operators == list()
 


### PR DESCRIPTION
Constant valued nodes can be considered as being function of time nodes with a period of 1 timestep, this reduces the amount of data written to SpiNNaker and should hopefully make the real-time experience _more real_.

@celiasmith, can you confirm this is an improvement for you?

I'll rebase to master.
