### PR TITLE
Replace Vertices with generic objects in netlists.

### DIFF
--- a/nengo_spinnaker/utils/place_and_route.py
+++ b/nengo_spinnaker/utils/place_and_route.py
@@ -1,6 +1,17 @@
 """Place and route utilities.
 """
+from __future__ import absolute_import
+
 import pickle
+
+from six import iteritems
+
+from collections import defaultdict
+
+from rig.netlist import Net
+
+from rig.place_and_route.constraints import (LocationConstraint,
+                                             RouteEndpointConstraint)
 
 from nengo_spinnaker.builder import Model
 from nengo_spinnaker.node_io import Ethernet
@@ -16,10 +27,44 @@ def create_network_netlist(network, n_steps, fp, dt=0.001):
     model.build(network, **node_io.builder_kwargs)
 
     # Build the netlist
-    netlist = model.make_netlist(n_steps)
+    netlist = model.make_netlist(n_steps).as_rig_arguments()
     pickle_netlist(netlist, fp)
 
 
-def pickle_netlist(netlist, fp, **kwargs):
-    """Dump a pickle of a netlist to a file."""
-    pickle.dump(netlist.as_rig_arguments(), fp, **kwargs)
+def pickle_netlist(netlist_dict, fp, **kwargs):
+    """Dump a pickle of a netlist to a file.
+
+    This function replaces all vertices with `object` instances so that
+    nengo-specific or project-specific dependencies are not included.
+    """
+    # {old_vertex: new_vertex, ...}
+    new_vertices = defaultdict(object)
+
+    netlist_dict["vertices_resources"] = {
+        new_vertices[vertex]: resources
+        for (vertex, resources)
+        in iteritems(netlist_dict["vertices_resources"])
+    }
+
+    netlist_dict["nets"] = [
+        Net(new_vertices[net.source],
+            [new_vertices[sink] for sink in net.sinks],
+            net.weight)
+        for net in netlist_dict["nets"]
+    ]
+
+    old_constraints = netlist_dict["constraints"]
+    netlist_dict["constraints"] = []
+    for constraint in old_constraints:
+        if isinstance(constraint, LocationConstraint):
+            netlist_dict["constraints"].append(
+                LocationConstraint(new_vertices[constraint.vertex],
+                                   constraint.location))
+        elif isinstance(constraint, RouteEndpointConstraint):
+            netlist_dict["constraints"].append(
+                RouteEndpointConstraint(new_vertices[constraint.vertex],
+                                        constraint.route))
+        else:
+            netlist_dict["constraints"].append(constraint)
+
+    pickle.dump(netlist_dict, fp, **kwargs)

--- a/tests/utils/test_place_and_route.py
+++ b/tests/utils/test_place_and_route.py
@@ -1,0 +1,51 @@
+"""Test netlist export works as expected."""
+
+import pytest
+
+import os
+
+from tempfile import mkstemp
+
+import pickle
+
+import nengo
+
+from nengo_spinnaker.utils.place_and_route import create_network_netlist
+
+
+@pytest.fixture
+def example_network():
+    with nengo.Network("Test network") as network:
+        a = nengo.Ensemble(200, 1)
+        b = nengo.Ensemble(200, 1)
+        nengo.Connection(a, b)
+    return network
+
+
+@pytest.yield_fixture
+def temp_filename():
+    name = mkstemp()[1]
+    yield name
+    os.remove(name)
+
+
+def test_create_network_netlist(example_network, temp_filename):
+    with open(temp_filename, "wb") as fp:
+        create_network_netlist(example_network, 1.0, fp)
+
+    with open(temp_filename, "rb") as fp:
+        netlist = pickle.load(fp)
+
+    # The compiled network should contain one core for each ensemble
+    assert len(netlist["vertices_resources"]) == 2
+
+    for vertex in netlist["vertices_resources"]:
+        # Should be a native Python object and nothing more fancy!
+        assert type(vertex) is object
+
+    # The vertices should be connected together with a single net
+    assert len(netlist["nets"]) == 1
+    assert netlist["nets"][0].source in netlist["vertices_resources"]
+    assert len(netlist["nets"][0].sinks) == 1
+    assert netlist["nets"][0].sinks[0] in netlist["vertices_resources"]
+    assert netlist["nets"][0].source is not netlist["nets"][0].sinks[0]


### PR DESCRIPTION
This change makes the netlists dumped by create_network_netlist contain nothing
but Rig Nets and python objects with no references to internal types. This
makes the pickling process more robust on Python 2 and avoids unnecessary
dependencies being required by the user of the netlist.

@mundya Would you be happy to sign this off?
