### PR TITLE
Remove passnodes

### DIFF
--- a/nengo_spinnaker/builder/node.py
+++ b/nengo_spinnaker/builder/node.py
@@ -131,10 +131,11 @@ class NodeIOController(object):
 
         # Create a new connection from the Node to the Probe and then get the
         # model to build this.
-        seed = model.seeds[probe]
-        conn = nengo.Connection(probe.target, probe, synapse=probe.synapse,
-                                seed=seed, add_to_container=False)
-        model.make_connection(conn)
+        if probe.target.output is not None:
+            seed = model.seeds[probe]
+            conn = nengo.Connection(probe.target, probe, synapse=probe.synapse,
+                                    seed=seed, add_to_container=False)
+            model.make_connection(conn)
 
     def get_node_source(self, model, cn):
         """Get the source for a connection originating from a Node."""

--- a/nengo_spinnaker/utils/passthrough_nodes.py
+++ b/nengo_spinnaker/utils/passthrough_nodes.py
@@ -1,0 +1,161 @@
+"""Collection of tools necessary to modify networks to remove passthrough
+Nodes.
+"""
+import nengo
+from nengo.synapses import LinearFilter
+from nengo.utils.builder import find_all_io, full_transform
+import numpy as np
+from numpy.polynomial.polynomial import polymul
+
+from .probes import probe_target
+
+
+def add_passthrough_node_to_probe_connections(network):
+    """Adds new connections to the network to connect passthrough Nodes probes
+    which target them.
+    """
+    # For all of the probes in the network, if any of them refer to a
+    # passthrough Node then add a connection from the passthrough Node to the
+    # probe.
+    for probe in network.all_probes:
+        obj = probe_target(probe)
+
+        # If the target is a passthrough Node then add a connection
+        if isinstance(obj, nengo.Node) and obj.output is None:
+            with network:
+                nengo.Connection(probe.target, probe, seed=probe.seed,
+                                 synapse=probe.synapse)
+
+
+def combine_lti_synapses(a, b):
+    """Combine two LTI filters."""
+    # Assert that both the synapses are LTI synapses
+    assert (isinstance(a, nengo.synapses.LinearFilter) and
+            isinstance(b, nengo.synapses.LinearFilter))
+
+    # Combine
+    return nengo.synapses.LinearFilter(polymul(a.num, b.num),
+                                       polymul(a.den, b.den))
+
+
+def remove_passthrough_nodes(network):
+    """Return a new network with all the passthrough Nodes removed and a
+    mapping from new connections to connections the decoders of which they can
+    use.
+    """
+    # Get a list of the connections and a complete map of objects to inputs and
+    # outputs.
+    conns = list(network.all_connections)
+    inputs, outputs = find_all_io(conns)
+
+    # Prepare to create a map of which connections can just use the decoders
+    # from an earlier connection.
+    connection_decoders = dict()
+
+    # Create a new (flattened) network containing all elements from the
+    # original network apart from passthrough Nodes.
+    with nengo.Network() as m:
+        # Add all of the original ensembles
+        for ens in network.all_ensembles:
+            m.add(ens)
+
+        # Add all of the original probes
+        for probe in network.all_probes:
+            m.add(probe)
+
+    # For all the Nodes, if the Node is not a passthrough Node we add it as
+    # usual - otherwise we combine remove it and multiply together its
+    # input and output connections.
+    for node in network.all_nodes:
+        if node.output is not None:
+            with m:
+                m.add(node)
+            continue
+
+        # Remove the original connections associated with this passthrough
+        # Node from both the list of connections but also the lists
+        # associated with their pre- and post- objects.
+        conns_in = list(inputs[node])
+        conns_out = list(outputs[node])
+
+        for c in conns_in:
+            conns.remove(c)
+            outputs[c.pre_obj].remove(c)
+
+        for c in conns_out:
+            conns.remove(c)
+            inputs[c.post_obj].remove(c)
+
+        # For every outgoing connection
+        for out_conn in outputs[node]:
+            # For every incoming connection
+            for in_conn in inputs[node]:
+                use_pre_slice = in_conn.function is not None
+
+                # Create a new transform for the combined connections.  If
+                # the transform is zero then we don't bother adding a new
+                # connection and instead move onto the next combination. If the
+                # in connection doesn't have a function then we include the
+                # pre-slice in the transform, otherwise we ignore it.
+                transform = np.dot(
+                    full_transform(out_conn),
+                    full_transform(in_conn, slice_pre=not use_pre_slice)
+                )
+
+                if np.all(transform == 0.0):
+                    continue
+
+                # We determine if we can combine the synapses.  If we can't
+                # we raise an error because we can't do anything at the
+                # moment.
+                if out_conn.synapse is None or in_conn.synapse is None:
+                    # Trivial combination of synapses
+                    new_synapse = out_conn.synapse or in_conn.synapse
+                elif (isinstance(in_conn.synapse, LinearFilter) and
+                        isinstance(out_conn.synapse, LinearFilter)):
+                    # Combination of LTI systems
+                    print("Combining synapses of {} and {}".format(
+                        in_conn, out_conn))
+                    new_synapse = combine_lti_synapses(in_conn.synapse,
+                                                       out_conn.synapse)
+                else:
+                    # Can't combine these filters
+                    raise NotImplementedError(
+                        "Can't combine synapses of types {} and {}".format(
+                            in_conn.synapse.__class__.__name__,
+                            out_conn.synapse.__class__.__name__
+                        )
+                    )
+
+                # Create a new connection that combines the inputs and outputs.
+                new_c = nengo.Connection(
+                    in_conn.pre if use_pre_slice else in_conn.pre_obj,
+                    out_conn.post_obj,
+                    function=in_conn.function,
+                    synapse=new_synapse,
+                    transform=transform,
+                    add_to_container=False
+                )
+
+                # Add this connection to the list of connections to add to the
+                # model and the lists of outgoing and incoming connections for
+                # objects.
+                conns.append(new_c)
+                inputs[new_c.post_obj].append(new_c)
+                outputs[new_c.pre_obj].append(new_c)
+
+                # Determine which decoders should be used for this connection
+                # if the pre object is an ensemble.
+                if isinstance(in_conn.pre_obj, nengo.Ensemble):
+                    x = in_conn
+                    while x in connection_decoders:
+                        x = connection_decoders[x]
+                    connection_decoders[new_c] = x
+
+    # Add all the connections
+    with m:
+        for c in conns:
+            m.add(c)
+
+    # Return the new network and map of connections
+    return m, connection_decoders

--- a/nengo_spinnaker/utils/probes.py
+++ b/nengo_spinnaker/utils/probes.py
@@ -1,0 +1,11 @@
+from nengo.base import ObjView
+
+
+def probe_target(probe):
+    """Get the target object of a probe."""
+    if isinstance(probe.target, ObjView):
+        # If the target is an object view then return the underlying object
+        return probe.target.obj
+    else:
+        # Otherwise return the target
+        return probe.target

--- a/tests/utils/test_passthrough_nodes_utils.py
+++ b/tests/utils/test_passthrough_nodes_utils.py
@@ -1,0 +1,209 @@
+import nengo
+import numpy as np
+import pytest
+
+from nengo_spinnaker.utils.passthrough_nodes import (
+    add_passthrough_node_to_probe_connections, combine_lti_synapses,
+    remove_passthrough_nodes
+)
+
+
+def test_add_pasthrough_node_to_probe_connections():
+    """Test that connections from passthrough Nodes to Probes are added
+    correctly.
+    """
+    # Create a network with some awkward nesting
+    with nengo.Network() as network:
+        with nengo.Network():
+            ptn = nengo.Node(size_in=3)
+
+        with nengo.Network():
+            probe = nengo.Probe(ptn[:], synapse=0.05)
+            probe.seed = 1234
+
+        probe2 = nengo.Probe(ptn)
+
+        # And another completely unrelated probe
+        e = nengo.Ensemble(100, 1)
+        nengo.Probe(e)
+
+    # Add the connection
+    add_passthrough_node_to_probe_connections(network)
+
+    # Check it is correct
+    for conn in network.all_connections:
+        if conn.post is probe:
+            assert conn.pre_obj is ptn
+            assert conn.pre_slice == slice(None)
+            assert conn.seed == probe.seed
+            assert conn.synapse.tau == 0.05
+        else:
+            assert conn.pre is ptn
+            assert conn.post is probe2
+
+
+@pytest.mark.parametrize(
+    "synapse_1, synapse_2, expected_synapse",
+    [(nengo.Lowpass(0.05), nengo.Lowpass(0.01),
+      nengo.synapses.LinearFilter([1], [0.05*0.01, 0.05+0.01, 1]))]
+)
+def test_combine_lti_synapses(synapse_1, synapse_2, expected_synapse):
+    # Combine the synapses
+    new_synapse = combine_lti_synapses(synapse_1, synapse_2)
+
+    # Assert this is as expected
+    assert isinstance(new_synapse, nengo.synapses.LinearFilter)
+    assert np.all(new_synapse.num == expected_synapse.num)
+    assert np.all(new_synapse.den == expected_synapse.den)
+
+
+def test_remove_passthrough_nodes():
+    """Test that passthrough nodes are correctly removed from the following
+    network:
+
+       E01 --\                /--> E11
+              > PN1 ---> PN2 >
+       E02 --/                \--> E12
+    """
+    # Create the network
+    with nengo.Network() as network:
+        input_node = nengo.Node([0, 1])
+        e01 = nengo.Ensemble(100, 2)
+        e02 = nengo.Ensemble(100, 2)
+
+        pn1 = nengo.Node(size_in=4)
+        pn2 = nengo.Node(size_in=4)
+
+        e11 = nengo.Ensemble(100, 2)
+        e12 = nengo.Ensemble(100, 2)
+
+        # Add the connections
+        nengo.Connection(input_node, e01)
+        c1 = nengo.Connection(e01, pn1[:2], synapse=None)
+        c2 = nengo.Connection(e02, pn1[2:], synapse=None)
+        nengo.Connection(pn1, pn2[[2, 3, 0, 1]], synapse=None)
+        nengo.Connection(pn2[:2], e12, synapse=0.03)
+        nengo.Connection(pn2[2:], e11, synapse=0.02)
+
+        # Probe one of the ensembles
+        p = nengo.Probe(e12)
+
+    # Remove the passthrough nodes, this should return a simplified network and
+    # a mapping from connections to the connection whose decoder they should
+    # use.
+    new_net, decoder_sources = remove_passthrough_nodes(network)
+
+    assert set(new_net.all_ensembles) == set(network.all_ensembles)
+    assert new_net.all_nodes == [input_node]
+    assert new_net.all_probes == [p]
+    assert len(new_net.all_connections) == 3
+
+    for conn in new_net.all_connections:
+        if conn.pre_obj is e01:
+            assert conn.post_obj is e11
+            assert conn.synapse.tau == 0.02
+            assert np.all(conn.transform == np.eye(2))
+
+            assert decoder_sources[conn] is c1
+        elif conn.pre_obj is e02:
+            assert conn.post_obj is e12
+            assert conn.synapse.tau == 0.03
+            assert np.all(conn.transform == np.eye(2))
+
+            assert decoder_sources[conn] is c2
+        else:
+            assert conn.pre_obj is input_node
+
+
+def test_remove_passthrough_nodes_combines_lti_synapses():
+    with nengo.Network() as network:
+        a = nengo.Node([1.0])
+        b = nengo.Node(size_in=1)
+        c = nengo.Ensemble(100, 1)
+
+        ab = nengo.Connection(a, b, synapse=0.01)
+        nengo.Connection(b, c, synapse=0.02)
+
+    # Remove passthrough Nodes
+    new_net, conns_decoders = remove_passthrough_nodes(network)
+
+    # Check the new single connection
+    assert len(new_net.all_connections) == 1
+    assert np.all(new_net.all_connections[0].synapse.num == [1])
+    assert np.all(new_net.all_connections[0].synapse.den ==
+                  [0.01*0.02, 0.01+0.02, 1.0])
+
+
+def test_remove_passthrough_nodes_fails_combines_synapses():
+    with nengo.Network() as network:
+        a = nengo.Ensemble(100, 1)
+        b = nengo.Node(size_in=1)
+        c = nengo.Ensemble(100, 1)
+
+        ab = nengo.Connection(a, b, synapse=nengo.synapses.Triangle(0.01))
+        nengo.Connection(b, c, synapse=nengo.synapses.Triangle(0.02))
+
+    # Remove passthrough Nodes
+    with pytest.raises(NotImplementedError) as excinfo:
+        remove_passthrough_nodes(network)
+    assert "Triangle" in str(excinfo.value)
+
+
+def test_remove_passthrough_nodes_with_function():
+    with nengo.Network() as network:
+        a = nengo.Ensemble(100, 5)
+        b = nengo.Node(size_in=2)
+        c = nengo.Ensemble(100, 2)
+
+        ab = nengo.Connection(a, b, function=lambda x: x[:2], synapse=None)
+        nengo.Connection(b, c, synapse=None)
+
+    # Remove passthrough Nodes
+    new_net, conns_decoders = remove_passthrough_nodes(network)
+
+    # Check the new single connection
+    assert len(new_net.all_connections) == 1
+    assert new_net.all_connections[0].function is ab.function
+
+
+def test_remove_passthrough_nodes_with_preslices_no_function():
+    with nengo.Network() as network:
+        a = nengo.Ensemble(100, 5)
+        b = nengo.Node(size_in=2)
+        c = nengo.Node(size_in=1)
+        d = nengo.Ensemble(100, 1)
+
+        ab = nengo.Connection(a[:2], b, synapse=None)
+        bc = nengo.Connection(b[0], c, synapse=None)
+        cd = nengo.Connection(c[:], d, synapse=None)
+
+    # Remove passthrough Nodes
+    new_net, conns_decoders = remove_passthrough_nodes(network)
+
+    # Check the new single connection
+    assert len(new_net.all_connections) == 1
+    assert new_net.all_connections[0].pre is a
+    assert new_net.all_connections[0].post_obj is d
+    assert np.all(new_net.all_connections[0].transform == [[1, 0, 0, 0, 0]])
+
+
+def test_remove_passthrough_nodes_with_preslices_with_function():
+    with nengo.Network() as network:
+        a = nengo.Ensemble(100, 5)
+        b = nengo.Node(size_in=2)
+        c = nengo.Node(size_in=1)
+        d = nengo.Ensemble(100, 1)
+
+        ab = nengo.Connection(a[:2], b, synapse=None, function=lambda x: x)
+        bc = nengo.Connection(b[0], c, synapse=None)
+        cd = nengo.Connection(c[:], d, synapse=None)
+
+    # Remove passthrough Nodes
+    new_net, conns_decoders = remove_passthrough_nodes(network)
+
+    # Check the new single connection
+    assert len(new_net.all_connections) == 1
+    assert new_net.all_connections[0].pre_obj is a
+    assert new_net.all_connections[0].pre_slice == slice(2)
+    assert new_net.all_connections[0].post_obj is d
+    assert np.all(new_net.all_connections[0].transform == [[1, 0]])

--- a/tests/utils/test_probes_utils.py
+++ b/tests/utils/test_probes_utils.py
@@ -1,0 +1,20 @@
+import nengo
+from nengo_spinnaker.utils.probes import probe_target
+
+
+def test_probe_target_no_slice():
+    # Create a network containing a probe
+    with nengo.Network():
+        a = nengo.Ensemble(100, 1)
+        p = nengo.Probe(a)
+
+    assert probe_target(p) is a
+
+
+def test_probe_target_with_slice():
+    # Create a network containing a probe
+    with nengo.Network():
+        a = nengo.Ensemble(100, 2)
+        p = nengo.Probe(a[0])
+
+    assert probe_target(p) is a


### PR DESCRIPTION
Removes pass nodes with two key features:
1. Keeps a map of which connections will use the same decoders and so solves only once
2. Combines filters wherever possible (this will mesh with #43 at some point)
- [x] Combine `probe_target` and `target_obj` somewhere
- [ ] Set the seeds on connections and objects hierarchically before flattening the network
- [x] Ensure the tests are reasonable

@tcstewar, code review and testing would be much appreciated, thank you :)
