### PR TITLE
Full realtime sim up and running

### DIFF
--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -82,6 +82,7 @@ class Simulator(object):
         self.model.decoder_cache.shrink()
         self.dt = self.model.dt
         self._closed = False  # Whether the simulator has been closed or not
+        self._running = False
 
         self.host_sim = self._create_host_sim()
 
@@ -188,6 +189,7 @@ class Simulator(object):
             io_thread = self.io_controller.spawn()
 
             # Run the simulation
+            self._running = True
             try:
                 # Prep
                 exp_time = steps * (self.model.machine_timestep / float(1e6))
@@ -246,6 +248,9 @@ class Simulator(object):
                 raise ValueError("Cannot run an indefinite duration simulator "
                                  "for a fixed period of time.")
 
+            # Prepare the simulation
+            self.netlist.before_simulation(self, None)
+
             # Get a new thread for the IO
             io_thread = self.io_controller.spawn()
 
@@ -261,7 +266,7 @@ class Simulator(object):
                 self.controller.send_signal("cont")
 
             # Allow the local simulator to run
-            self._halt = True
+            self._halt = False
 
             # Run the simulation
             try:

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -83,6 +83,7 @@ class Simulator(object):
         self.dt = self.model.dt
         self._closed = False  # Whether the simulator has been closed or not
         self._running = False
+        self._halt = False
 
         self.host_sim = self._create_host_sim()
 
@@ -339,6 +340,8 @@ class Simulator(object):
         """Clean the SpiNNaker board and prevent further simulation."""
         # Stop the application
         self._closed = True
+        if not self._halt:
+            self.stop()
         self.io_controller.close()
         self.controller.send_signal("stop")
 


### PR DESCRIPTION
Built upon your changes and tested that it works using the following script. Closing the simulation works in both in the case that you run `sim.run(None)` in a new thread and in the case that you have a different thread stopping the simulation.

``` python
import thread
import nengo
import numpy as np
import nengo_spinnaker
import time

model = nengo.Network(label="NetworkName")


with model:
    in_A = nengo.Node(output=np.sin)
    A = nengo.Ensemble(50, 1)
    out_A = nengo.Node(size_in=1)

    nengo.Connection(in_A, A)
    nengo.Connection(A, out_A)

sim = nengo_spinnaker.Simulator(model, period=None)


def sim_stop():
    global sim
    time.sleep(20)
    sim.stop()

thread.start_new_thread(sim_stop, ())
with sim:
    print "Sim inc"
    sim.run(None)
    print "Sim closed"

print "Board wiped"
```
