### PR TITLE
Run Nengo's test suite

### DIFF
--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -8,6 +8,7 @@ from rig.machine_control.consts import AppState
 from rig.machine import Cores
 import six
 import time
+import warnings
 
 from .builder import Model
 from .node_io import Ethernet
@@ -49,7 +50,7 @@ class Simulator(object):
     def _remove_simulator(cls, simulator):
         cls._open_simulators.remove(simulator)
 
-    def __init__(self, network, dt=0.001, period=10.0):
+    def __init__(self, network, dt=0.001, period=10.0, seed=None):
         """Create a new Simulator with the given network.
 
         Parameters
@@ -58,6 +59,12 @@ class Simulator(object):
             Duration of one period of the simulator. This determines how much
             memory will be allocated to store precomputed and probed data.
         """
+        if len(self._open_simulators) > 0:
+            warnings.warn("Another simulator exists. Closing it.")
+            _close_open_simulators()
+        if seed is not None:
+            warnings.warn("Seed will be ignored.")
+
         # Add this simulator to the set of open simulators
         Simulator._add_simulator(self)
 
@@ -104,6 +111,7 @@ class Simulator(object):
 
         # Holder for probe data
         self.data = {}
+        self.data.update(self.model.params)
 
         # Holder for profiling data
         self.profiler_data = {}

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import atexit
 import logging
 import nengo
@@ -7,6 +9,7 @@ from rig.machine_control import MachineController
 from rig.machine_control.consts import AppState
 from rig.machine import Cores
 import six
+import sys
 import time
 import warnings
 
@@ -59,12 +62,10 @@ class Simulator(object):
             Duration of one period of the simulator. This determines how much
             memory will be allocated to store precomputed and probed data.
         """
-        if len(self._open_simulators) > 0:
-            warnings.warn("Another simulator exists. Closing it.")
-            _close_open_simulators()
         if seed is not None:
             warnings.warn("Seed will be ignored.")
 
+        self._closed = False  # Whether the simulator has been closed or not
         # Add this simulator to the set of open simulators
         Simulator._add_simulator(self)
 
@@ -105,7 +106,6 @@ class Simulator(object):
 
         self.model.decoder_cache.shrink()
         self.dt = self.model.dt
-        self._closed = False  # Whether the simulator has been closed or not
 
         self.host_sim = self._create_host_sim()
 
@@ -328,5 +328,6 @@ def _close_open_simulators():
         # Ignore any errors which may occur during this shut-down process.
         try:
             sim.close()
-        except:
-            pass
+        except Exception as e:
+            # But print them for debugging purposes
+            print(str(e), file=sys.stderr)

--- a/nengo_spinnaker/test_options.py
+++ b/nengo_spinnaker/test_options.py
@@ -1,0 +1,6 @@
+import nengo.tests.options
+
+def pytest_addoption(parser):
+    parser.addoption('--nengo', nargs='?', default=False, const=True,
+                     help='Also run the Nengo test suite.')
+    nengo.tests.options.pytest_addoption(parser)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules
+addopts = --doctest-modules -p nengo.tests.options

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules -p nengo.tests.options
+addopts = --doctest-modules -p nengo_spinnaker.test_options

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,11 @@ def Simulator(request):
     return nengo_spinnaker.simulator.Simulator
 
 
+def pytest_runtest_setup(item):
+    if not item.config.getvalue("nengo") and "Simulator" in item.funcargnames:
+        pytest.skip("Nengo tests not requested.")
+
+
 def pytest_generate_tests(metafunc):
     if "nl" in metafunc.funcargnames:
         metafunc.parametrize("nl", [nengo.LIF])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,10 +20,12 @@ nengo.utils.testing.Recorder.get_filename = get_filename
 
 @pytest.fixture
 def Simulator(request):
-    while len(nengo_spinnaker.simulator.Simulator._open_simulators) > 0:
-        # This shouldn't happen, but does, so we ensure open sims are closed
+    if len(nengo_spinnaker.simulator.Simulator._open_simulators) > 0:
+        # This shouldn't happen, but just in case it does...
         print("Sim still open, closing...", file=sys.stderr)
         nengo_spinnaker.simulator._close_open_simulators()
+        # If something is still open, there's a bigger problem. Bail!
+        assert len(nengo_spinnaker.simulator.Simulator._open_simulators) == 0
     request.addfinalizer(nengo_spinnaker.simulator._close_open_simulators)
     return nengo_spinnaker.simulator.Simulator
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import fnmatch
+import os
+
+import nengo
+from nengo.tests.conftest import *
+from nengo.utils.testing import find_modules, allclose, load_functions
+
+import nengo_spinnaker
+
+
+# A monkey patch hack to solve a problem in Nengo master
+def get_filename(self, ext=''):
+    modparts = self.module_name.split('.')[1:]
+    return "%s.%s.%s" % ('.'.join(modparts), self.function_name, ext)
+nengo.utils.testing.Recorder.get_filename = get_filename
+
+
+@pytest.fixture
+def Simulator():
+    return nengo_spinnaker.Simulator
+
+
+def pytest_generate_tests(metafunc):
+    if "nl" in metafunc.funcargnames:
+        metafunc.parametrize("nl", [nengo.LIF])
+    if "nl_nodirect" in metafunc.funcargnames:
+        metafunc.parametrize("nl_nodirect", [nengo.LIF])

--- a/tests/test_nengo.py
+++ b/tests/test_nengo.py
@@ -128,6 +128,14 @@ xfail('test.nengo.tests.test_node.test_passthrough_filter', "Similar...")
 xfail('test.nengo.tests.test_node.test_circular', "Looks right?")
 xfail('test.nengo.tests.test_processes.test_gaussian_whitenoise',
       "Processes not implemented yet?")
+xfail('test.nengo.tests.test_processes.test_whitesignal*',
+      "Processes not implemented yet? Or, tolerances are too tight...")
+xfail('test.nengo.tests.test_ensemble.test_constant_scalar',
+      "Last timepoint seems to be wrong? But the rest are good?")
+xfail('test.nengo.spa.tests.test_thalamus.test_nondefault_routing',
+      "valueC way off.")
+xfail('test.nengo.tests.test_synapses.test_decoders',
+      "Differences in representing time I think...")
 
 # These are just out of tolerance
 xfail('test.nengo.networks.tests.test_product.test_sine_waves',

--- a/tests/test_nengo.py
+++ b/tests/test_nengo.py
@@ -1,0 +1,154 @@
+"""
+Black-box testing of the SpiNNaker simulator.
+
+TestCase classes are added automatically from
+nengo.tests, but you can still run individual
+test files like this:
+
+$ py.test tests/test_nengo.py -k test_ensemble.test_scalar
+
+See http://pytest.org/latest/usage.html for more invocations.
+
+"""
+import fnmatch
+import os
+
+from nengo.utils.testing import find_modules, allclose, load_functions
+import nengo
+import pytest
+
+import nengo_spinnaker
+
+
+def xfail(pattern, msg):
+    for key in tests:
+        if fnmatch.fnmatch(key, pattern):
+            tests[key] = pytest.mark.xfail(True, reason=msg)(tests[key])
+
+nengo_dir = os.path.dirname(nengo.__file__)
+modules = find_modules(nengo_dir, prefix='nengo')
+tests = load_functions(modules, arg_pattern='^Simulator$')
+
+xfail('test.nengo.networks.tests.test_circularconv.test_input_magnitude',
+      "LIFRate not implemented.")
+xfail('test.nengo.networks.tests.test_circularconv.test_neural_accuracy',
+      "LIFRate not implemented.")
+xfail('test.nengo.networks.tests.test_ensemblearray.test_neuronconnection',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.networks.tests.test_product.test_direct_mode*',
+      "No direct mode")
+xfail('test.nengo.networks.tests.test_workingmemory.test_inputgatedmemory',
+      "Scalar transform?")
+xfail('test.nengo.tests.test_cache.test_cache_works',
+      "No cache, also can't take in built model")
+xfail('test.nengo.utils.tests.test_connection.test_eval_point_decoding',
+      "Have to update transform to weights...")
+xfail('test.nengo.tests.test_connection.test_node_to_ensemble',
+      "No direct mode")
+xfail('test.nengo.tests.test_connection.test_neurons_to_*',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.tests.test_connection.test_weights',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.tests.test_connection.test_slicing',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.tests.test_connection.test_neuron_slicing',
+      "LIFRate not implemented.")
+xfail('test.nengo.tests.test_connection.test_shortfilter',
+      "Causes zero division error.")
+xfail('test.nengo.tests.test_connection.test_zerofilter',
+      "No direct mode")
+xfail('test.nengo.tests.test_connection.test_decoder_probe',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.tests.test_connection.test_transform_probe',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.tests.test_learning_rules.test_pes_*',
+      "PES not implemented yet.")
+xfail('test.nengo.tests.test_learning_rules.test_dt_dependence',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.tests.test_learning_rules.test_reset',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.tests.test_learning_rules.test_unsupervised',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.tests.test_neurons.test_lif',
+      "'refractory_time' probe not supported.")
+xfail('test.nengo.tests.test_neurons.test_lif_min_voltage',
+      "Min voltage is clamped at 0.")
+xfail('test.nengo.tests.test_neurons.test_izhikevich',
+      "Izhikevich neurons not implemented.")
+xfail('test.nengo.tests.test_neurons.test_alif*', "Only LIF implemented.")
+xfail('test.nengo.tests.test_neurons.test_reset',
+      "SpiNNaker does not currently support connections from Neurons")
+xfail('test.nengo.tests.test_node.test_args', "Not quite 0...")
+xfail('test.nengo.tests.test_node.test_unconnected_node',
+      "Nengo shouldn't call sim.step here...")
+xfail('test.nengo.tests.test_processes.test_reset',
+      "Reset not implemented.")
+xfail('test.nengo.tests.test_processes.test_whitesignal_continuity',
+      "Non-uniform sampling problem I'm guessing?")
+xfail('test.nengo.tests.test_probe.test_defaults',
+      "Probing Connections not supported.")
+xfail('test.nengo.tests.test_probe.test_input_probe',
+      "SpiNNaker does not support probing 'input' on Ensembles.")
+xfail('test.nengo.tests.test_probe.test_large',
+      "Non-uniform sampling problem I'm guessing?")
+xfail('test.nengo.tests.test_probe.test_multiple_probes',
+      "sampling rates not guaranteed I'm guessing?")
+xfail('test.nengo.tests.test_synapses.test_alpha',
+      "alpha synapse not implemented.")
+xfail('test.nengo.tests.test_synapses.test_linearfilter',
+      "analog=False filters not implemented yet.")
+xfail('test.nengo.tests.test_synapses.test_triangle',
+      "triangle synapse not implemented.")
+xfail('test.nengo.utils.tests.test_neurons.test_rates*',
+      "LIFRate not implemented.")
+xfail('test.nengo.utils.tests.test_ensemble.test_*_direct_mode',
+      "No direct mode")
+
+xfail('test.nengo.tests.test_neurons.test_lif_zero_tau_ref',
+      "Doesn't spike at all with tau_ref=0.")
+xfail('test.nengo.tests.test_ensemble.test_noise_gen',
+      "Injected noise doesn't work?")
+xfail('test.nengo.tests.test_connection.test_nonexistant_prepost',
+      "Fails with KeyError instead of ValueError")
+xfail('test.nengo.spa.tests.test_cortical.test_convolution',
+      "All are 0 instead of all but action 3")
+xfail('test.nengo.spa.tests.test_thalamus.test_routing',
+      "valueC is near 0 instead of > 0.8")
+xfail('test.nengo.tests.test_neurons.test_dt_dependence',
+      "RMSE is 893.21 but should be 10.0. dt makes a difference? "
+      "Or multiple sim issue.")
+xfail('test.nengo.tests.test_node.test_time',
+      "Not exact timesteps. We should make this OK.")
+xfail('test.nengo.tests.test_node.test_simple',
+      "Also a timestep issue.")
+xfail('test.nengo.tests.test_node.test_connected',
+      "Another timestep issue?")
+xfail('test.nengo.tests.test_node.test_passthrough', "Unsure")
+xfail('test.nengo.tests.test_node.test_passthrough_filter', "Similar...")
+xfail('test.nengo.tests.test_node.test_circular', "Looks right?")
+xfail('test.nengo.tests.test_processes.test_gaussian_whitenoise',
+      "Processes not implemented yet?")
+
+# These are just out of tolerance
+xfail('test.nengo.networks.tests.test_product.test_sine_waves',
+      "RMSE 0.2327 but should be < 0.2")
+xfail('test.nengo.spa.tests.test_assoc_mem.test_am_basic',
+      "similarity 0.9818 but should be > 0.99")
+xfail('test.nengo.spa.tests.test_basalganglia.test_basal_ganglia',
+      "Motor A and E not the same, though close")
+xfail('test.nengo.spa.tests.test_cortical.test_connect',
+      "match 0.8639 but should be > 0.9")
+xfail('test.nengo.tests.test_connection.test_vector',
+      "Close to -0.5, 0.25 but not quite...")
+xfail('test.nengo.tests.test_ensemble.test_constant_vector',
+      "Looks right until the last bit of the simulation?")
+xfail('test.nengo.tests.test_ensemble.test_scalar',
+      "Looks right, but tolerances are too tight here.")
+xfail('test.nengo.tests.test_ensemble.test_vector',
+      "Looks right, but tolerances are too tight here.")
+
+locals().update(tests)
+
+
+if __name__ == '__main__':
+    pytest.main(sys.argv)


### PR DESCRIPTION
This PR makes it possible to run tests from Nengo's test suite with `nengo_spinnaker.Simulator` instead of the default `nengo.Simulator`. To do so, execute:

``` bash
py.test tests/test_nengo.py
```

from the `nengo_spinnaker` directory.

I'm marking this as a work-in-progress because:
1. As much as I tried to hack it in without modifying the simulator itself, it's just not possible to automatically call `sim.close()` at the end of every test function, because in order to register a function to occur after the test has run, the simulator has to exist before the test, but obviously that can't happen because the tests create the simulator. So, I hacked it in by closing any open simulators when you make a new one. This isn't quite enough though, as when running through the whole test suite, by the end you will get `InsufficientResourceError`s and `SpiNNakerMemoryError`s relatively frequently, which will get more frequent if you rerun the test suite. Resetting the board fixes it temporarily. Not sure if there's a better way to free resources to solve this issue?
2. A lot of tests don't pass, so I mark them as expected failures (see most of `test_nengo.py`). It's quite possible that some of these tests can be made to pass with minor tweaks, so I wanted to put this out there to see if there are some easy tweaks that I can implement to raise the number of tests that pass.

---

For reference and/or interest, here's the full output from a run of the test suite. A lot of the assertions that fail for tolerance reasons have been marked as expected failures, but I thought showing the traceback would be helpful here.

``` python
ctnuser@ctngpu2:~/git/nengo_spinnaker$ py.test tests/test_nengo.py
============================== test session starts ===============================
platform linux2 -- Python 2.7.6 -- py-1.4.29 -- pytest-2.7.2
rootdir: /home/ctnuser/git/nengo_spinnaker, inifile: pytest.ini
collected 186 items

tests/test_nengo.py ..xxx...x..FxxF....F..F...F......sF.x..xxxx.xFxxxxF..........F....xxx.FFFF...................x.xxxxxXxxxxxxxxx....xxxXxxxxFxFFFFFF..x..x.Fxx.xx..FFFFFFFFFFxx.FssssFxxFxF.FFx...xxFxxssxxs

==================================== FAILURES ====================================
_____________ test.nengo.networks.tests.test_product.test_sine_waves _____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x4f6d3d0>, seed = 1372362929

    def test_sine_waves(Simulator, plt, seed):
        radius = 2
        dim = 5
        product = nengo.networks.Product(
            200, dim, radius, net=nengo.Network(seed=seed))

        func_A = lambda t: np.sqrt(radius)*np.sin(np.arange(1, dim+1)*2*np.pi*t)
        func_B = lambda t: np.sqrt(radius)*np.sin(np.arange(dim, 0, -1)*2*np.pi*t)
        with product:
            input_A = nengo.Node(func_A)
            input_B = nengo.Node(func_B)
            nengo.Connection(input_A, product.A)
            nengo.Connection(input_B, product.B)
            p = nengo.Probe(product.output, synapse=0.005)

        sim = Simulator(product)
        sim.run(1.0)

        t = sim.trange()
        AB = np.asarray(list(map(func_A, t))) * np.asarray(list(map(func_B, t)))
        delay = 0.013
        offset = np.where(t >= delay)[0]

        for i in range(dim):
            plt.subplot(dim+1, 1, i+1)
            plt.plot(t + delay, AB[:, i])
            plt.plot(t, sim.data[p][:, i])
        plt.xlim(right=t[-1])

>       assert rmse(AB[:len(offset), :], sim.data[p][offset, :]) < 0.2
E       assert 0.23270150888292909 < 0.2
E        +  where 0.23270150888292909 = rmse(array([[ 0.00039472,  0.00063157,  0.00071053,  0.00063157,  0.00039472],\n    ...08],\n       [ 0.05545929,  0.08924649,  0.10059475,  0.08924649,  0.05545929]]), array([[ 0.00878906, -0.0255127 ,  0.02346802, -0.04873657, -0.06466675],\n    ...55],\n       [ 0.08920288,  0.18908691,  0.28424072,  0.17532349,  0.08963013]]))

../nengo/nengo/networks/tests/test_product.py:41: AssertionError
_______________ test.nengo.spa.tests.test_assoc_mem.test_am_basic ________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x51d71d0>, seed = 1532190788
rng = <mtrand.RandomState object at 0x7fd286a52e40>

    def test_am_basic(Simulator, plt, seed, rng):
        """Basic associative memory test."""

        D = 64
        vocab = Vocabulary(D, rng=rng)
        vocab.parse('A+B+C+D')

        with nengo.Network('model', seed=seed) as m:
            am = AssociativeMemory(vocab)
            in_node = nengo.Node(output=vocab.parse("A").v, label='input')
            nengo.Connection(in_node, am.input)

            in_p = nengo.Probe(in_node)
            out_p = nengo.Probe(am.output, synapse=0.03)

        sim = Simulator(m)
        sim.run(0.2)
        t = sim.trange()

        plt.subplot(2, 1, 1)
        plt.plot(t, nengo.spa.similarity(sim.data[in_p], vocab))
        plt.ylabel("Input")
        plt.ylim(top=1.1)
        plt.legend(vocab.keys, loc='best')
        plt.subplot(2, 1, 2)
        plt.plot(t, nengo.spa.similarity(sim.data[out_p], vocab))
        plt.plot(t[t > 0.15], np.ones(t.shape)[t > 0.15] * 0.8, c='g', lw=2)
        plt.ylabel("Output")
        plt.legend(vocab.keys, loc='best')

>       assert similarity(sim.data[in_p][t > 0.15], vocab.parse("A").v) > 0.99
E       assert 0.98183876012410931 > 0.99
E        +  where 0.98183876012410931 = similarity(array([[-0.11312866,  0.10983276, -0.06863403, ...,  0.08477783,\n         0.01... 0.        ,  0.        , ...,  0.        ,\n         0.01104736, -0.11676025]]), array([-0.11313913,  0.10982337, -0.06864404, -0.18610799, -0.27389513,\n      ...31383, -0.00552365,\n       -0.13018342,  0.0847789 ,  0.01104592, -0.1167656 ]))
E        +    where array([-0.11313913,  0.10982337, -0.06864404, -0.18610799, -0.27389513,\n      ...31383, -0.00552365,\n       -0.13018342,  0.0847789 ,  0.01104592, -0.1167656 ]) = <nengo.spa.pointer.SemanticPointer object at 0x51d73d0>.v
E        +      where <nengo.spa.pointer.SemanticPointer object at 0x51d73d0> = <bound method Vocabulary.parse of <nengo.spa.vocab.Vocabulary object at 0x51d7410>>('A')
E        +        where <bound method Vocabulary.parse of <nengo.spa.vocab.Vocabulary object at 0x51d7410>> = <nengo.spa.vocab.Vocabulary object at 0x51d7410>.parse

../nengo/nengo/spa/tests/test_assoc_mem.py:42: AssertionError
___________ test.nengo.spa.tests.test_basalganglia.test_basal_ganglia ____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, seed = 1951851919
plt = <nengo.utils.testing.Mock object at 0x520e9d0>

    def test_basal_ganglia(Simulator, seed, plt):
        model = spa.SPA(seed=seed)

        with model:
            model.vision = spa.Buffer(dimensions=16)
            model.motor = spa.Buffer(dimensions=16)
            model.compare = spa.Compare(dimensions=16)

            # test all acceptable condition formats
            actions = spa.Actions(
                '0.5 --> motor=A',
                'dot(vision, CAT) --> motor=B',
                'dot(vision*CAT, DOG) --> motor=C',
                '2*dot(vision, CAT*0.5) --> motor=D',
                'dot(vision, CAT) + 0.5 - dot(vision,CAT) --> motor=E',
                'dot(vision, PARROT) + compare --> motor=F',
                '0.5*dot(vision, MOUSE) + 0.5*compare --> motor=G',
                '( dot(vision, MOUSE) - compare ) * 0.5 --> motor=H'
            )
            model.bg = spa.BasalGanglia(actions)

            def input(t):
                if t < 0.1:
                    return '0'
                elif t < 0.2:
                    return 'CAT'
                elif t < 0.3:
                    return 'DOG*~CAT'
                elif t < 0.4:
                    return 'PARROT'
                elif t < 0.5:
                    return 'MOUSE'
                else:
                    return '0'
            model.input = spa.Input(vision=input,
                                    compare_A='SHOOP', compare_B='SHOOP')
            p = nengo.Probe(model.bg.input, 'output', synapse=0.03)

        sim = Simulator(model)
        sim.run(0.5)
        t = sim.trange()

        plt.plot(t, sim.data[p])
        plt.legend(["A", "B", "C", "D", "E", "F", "G", "H"])
        plt.title('Basal Ganglia output')

        # assert the basal ganglia is prioritizing things correctly
        # Motor F
        assert sim.data[p][t == 0.4, 5] > 0.8
        # Motor G
        assert sim.data[p][t == 0.5, 6] > 0.8
        # Motor A
        assert 0.6 > sim.data[p][t == 0.1, 0] > 0.4
        # Motor B
        assert sim.data[p][t == 0.2, 1] > 0.8
        # Motor C
        assert sim.data[p][t == 0.3, 2] > 0.6

        # Motor B should be the same as Motor D
        assert np.allclose(sim.data[p][:, 1], sim.data[p][:, 3])
        # Motor A should be the same as Motor E
>       assert np.allclose(sim.data[p][:, 0], sim.data[p][:, 4])
E       assert <function allclose at 0x26b8b90>(array([ 0.        ,  0.00643921,  0.01657104,  0.02874756,  0.04196167,\n      ...53516,\n        0.49853516,  0.49853516,  0.49853516,  0.49853516,  0.49853516]), array([ 0.        ,  0.00643921,  0.01657104,  0.02874756,  0.04196167,\n      ...07739,\n        0.49807739,  0.49807739,  0.49807739,  0.49807739,  0.49807739]))
E        +  where <function allclose at 0x26b8b90> = np.allclose

../nengo/nengo/spa/tests/test_basalganglia.py:69: AssertionError
________________ test.nengo.spa.tests.test_cortical.test_connect _________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, seed = 1739818926

    def test_connect(Simulator, seed):
        with spa.SPA(seed=seed) as model:
            model.buffer1 = spa.Buffer(dimensions=16)
            model.buffer2 = spa.Buffer(dimensions=16)
            model.buffer3 = spa.Buffer(dimensions=16)
            model.cortical = spa.Cortical(spa.Actions('buffer2=buffer1',
                                                      'buffer3=~buffer1'))
            model.input = spa.Input(buffer1='A')

        output2, vocab = model.get_module_output('buffer2')
        output3, vocab = model.get_module_output('buffer3')

        with model:
            p2 = nengo.Probe(output2, 'output', synapse=0.03)
            p3 = nengo.Probe(output3, 'output', synapse=0.03)

        sim = Simulator(model)
        sim.run(0.2)

        match = np.dot(sim.data[p2], vocab.parse('A').v)
        assert match[199] > 0.9
        match = np.dot(sim.data[p3], vocab.parse('~A').v)
>       assert match[199] > 0.9
E       assert 0.8639036985343086 > 0.9

../nengo/nengo/spa/tests/test_cortical.py:30: AssertionError
______________ test.nengo.spa.tests.test_cortical.test_convolution _______________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x6033890>, seed = 1637343640

    def test_convolution(Simulator, plt, seed):
        D = 5
        with spa.SPA(seed=seed) as model:
            model.inA = spa.Buffer(dimensions=D)
            model.inB = spa.Buffer(dimensions=D)
            model.outAB = spa.Buffer(dimensions=D)
            model.outABinv = spa.Buffer(dimensions=D)
            model.outAinvB = spa.Buffer(dimensions=D)
            model.outAinvBinv = spa.Buffer(dimensions=D)

            model.cortical = spa.Cortical(spa.Actions(
                'outAB = inA * inB',
                'outABinv = inA * ~inB',
                'outAinvB = ~inA * inB',
                'outAinvBinv = ~inA * ~inB',
                ))
            nengo.Connection(nengo.Node([0, 1, 0, 0, 0]), model.inA.state.input)
            nengo.Connection(nengo.Node([0, 0, 1, 0, 0]), model.inB.state.input)

            pAB = nengo.Probe(model.outAB.state.output, synapse=0.03)
            pABinv = nengo.Probe(model.outABinv.state.output, synapse=0.03)
            pAinvB = nengo.Probe(model.outAinvB.state.output, synapse=0.03)
            pAinvBinv = nengo.Probe(model.outAinvBinv.state.output, synapse=0.03)

        sim = Simulator(model)
        sim.run(0.2)

        t = sim.trange()
        plt.subplot(4, 1, 1)
        plt.ylabel('A*B')
        plt.axhline(0.85, c='k')
        plt.plot(t, sim.data[pAB])
        plt.subplot(4, 1, 2)
        plt.ylabel('A*~B')
        plt.axhline(0.85, c='k')
        plt.plot(t, sim.data[pABinv])
        plt.subplot(4, 1, 3)
        plt.ylabel('~A*B')
        plt.axhline(0.85, c='k')
        plt.plot(t, sim.data[pAinvB])
        plt.subplot(4, 1, 4)
        plt.ylabel('~A*~B')
        plt.axhline(0.85, c='k')
        plt.plot(t, sim.data[pAinvBinv])

        # Check results.  Since A is [0,1,0,0,0] and B is [0,0,1,0,0], this means:
        #    ~A = [0,0,0,0,1]
        #    ~B = [0,0,0,1,0]
        #   A*B = [0,0,0,1,0]
        #  A*~B = [0,0,0,0,1]
        #  ~A*B = [0,1,0,0,0]
        # ~A*~B = [0,0,1,0,0]
        # (Remember that X*[1,0,0,0,0]=X (identity transform) and X*[0,1,0,0,0]
        #  is X rotated to the right once)

        # Ideal answer: A*B = [0,0,0,1,0]
>       assert np.allclose(np.mean(sim.data[pAB][-10:], axis=0),
                           np.array([0, 0, 0, 1, 0]), atol=0.15)
E       assert <function allclose at 0x26b8b90>(array([ 0.05593567, -0.04281616,  0.00698547, -0.02251892,  0.01444702]), array([0, 0, 0, 1, 0]), atol=0.15)
E        +  where <function allclose at 0x26b8b90> = np.allclose
E        +  and   array([ 0.05593567, -0.04281616,  0.00698547, -0.02251892,  0.01444702]) = <function mean at 0x26b7758>(array([[ 0.05651855, -0.04946899,  0.00314331, -0.02279663,  0.02032471],\n    ...25],\n       [ 0.04998779, -0.03594971, -0.00210571, -0.01821899, -0.00512695]]), axis=0)
E        +    where <function mean at 0x26b7758> = np.mean
E        +  and   array([0, 0, 0, 1, 0]) = <built-in function array>([0, 0, 0, 1, 0])
E        +    where <built-in function array> = np.array

../nengo/nengo/spa/tests/test_cortical.py:174: AssertionError
________________ test.nengo.spa.tests.test_thalamus.test_routing _________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, seed = 868945533
plt = <nengo.utils.testing.Mock object at 0x626e690>

    def test_routing(Simulator, seed, plt):
        D = 3
        model = spa.SPA(seed=seed)
        with model:
            model.ctrl = spa.Buffer(16, label='ctrl')

            def input_func(t):
                if t < 0.2:
                    return 'A'
                elif t < 0.4:
                    return 'B'
                else:
                    return 'C'
            model.input = spa.Input(ctrl=input_func)

            model.buff1 = spa.Buffer(D, label='buff1')
            model.buff2 = spa.Buffer(D, label='buff2')
            model.buff3 = spa.Buffer(D, label='buff3')

            node1 = nengo.Node([0, 1, 0])
            node2 = nengo.Node([0, 0, 1])

            nengo.Connection(node1, model.buff1.state.input)
            nengo.Connection(node2, model.buff2.state.input)

            actions = spa.Actions('dot(ctrl, A) --> buff3=buff1',
                                  'dot(ctrl, B) --> buff3=buff2',
                                  'dot(ctrl, C) --> buff3=buff1*buff2',
                                  )
            model.bg = spa.BasalGanglia(actions)
            model.thal = spa.Thalamus(model.bg)

            buff3_probe = nengo.Probe(model.buff3.state.output, synapse=0.03)

        sim = Simulator(model)
        sim.run(0.6)

        data = sim.data[buff3_probe]

        plt.plot(sim.trange(), data)

        valueA = np.mean(data[150:200], axis=0)  # should be [0, 1, 0]
        valueB = np.mean(data[350:400], axis=0)  # should be [0, 0, 1]
        valueC = np.mean(data[550:600], axis=0)  # should be [1, 0, 0]

        assert valueA[0] < 0.2
        assert valueA[1] > 0.8
        assert valueA[2] < 0.2

        assert valueB[0] < 0.2
        assert valueB[1] < 0.2
        assert valueB[2] > 0.8

>       assert valueC[0] > 0.8
E       assert 0.0388409423828125 > 0.8

../nengo/nengo/spa/tests/test_thalamus.py:125: AssertionError
_______________ test.nengo.tests.test_connection.test_vector[nl0] ________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x54ef810>, seed = 360384391

    def test_vector(Simulator, nl, plt, seed):
        N1, N2 = 50, 50
        transform = [-1, 0.5]

        m = nengo.Network(seed=seed)
        with m:
            m.config[nengo.Ensemble].neuron_type = nl()
            u = nengo.Node(output=[0.5, 0.5])
            a = nengo.Ensemble(N1, dimensions=2)
            b = nengo.Ensemble(N2, dimensions=2)
            nengo.Connection(u, a)
            nengo.Connection(a, b, transform=transform)

            up = nengo.Probe(u, 'output')
            bp = nengo.Probe(b, synapse=0.03)

        sim = Simulator(m)
        sim.run(0.2)
        t = sim.trange()
        x = sim.data[up]
        y = x * transform
        yhat = sim.data[bp]

        plt.plot(t, y, '--')
        plt.plot(t, yhat)

>       assert np.allclose(y[-10:], yhat[-10:], atol=.1, rtol=.01)
E       assert <function allclose at 0x26b8b90>(array([[-0.5 ,  0.25],\n       [-0.5 ,  0.25],\n       [-0.5 ,  0.25],\n       [-...,  0.25],\n       [-0.5 ,  0.25],\n       [-0.5 ,  0.25],\n       [-0.  ,  0.  ]]), array([[-0.51785278,  0.25558472],\n       [-0.50949097,  0.25845337],\n       [...48938 ],\n       [-0.49920654,  0.24679565],\n       [-0.52581787,  0.256073  ]]), atol=0.1, rtol=0.01)
E        +  where <function allclose at 0x26b8b90> = np.allclose

../nengo/nengo/tests/test_connection.py:314: AssertionError
___________ test.nengo.tests.test_connection.test_function_output_size ___________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x68c4ed0>, seed = 328274607

    def test_function_output_size(Simulator, plt, seed):
        """Try a function that outputs both 0-d and 1-d arrays"""
        def bad_function(x):
            return x if x > 0 else 0

        model = nengo.Network(seed=seed)
        with model:
            u = nengo.Node(output=lambda t: (t - 0.1) * 10)
            a = nengo.Ensemble(n_neurons=100, dimensions=1)
            b = nengo.Ensemble(n_neurons=100, dimensions=1)
            nengo.Connection(u, a, synapse=None)
            nengo.Connection(a, b, synapse=None, function=bad_function)
            up = nengo.Probe(u)
            bp = nengo.Probe(b, synapse=0.03)

>       sim = Simulator(model)

../nengo/nengo/tests/test_connection.py:525:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x68c4990>
size = 1772, tag = 1, x = 3, y = 4, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 1772 bytes of SDRAM on chip (3, 4). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
____ test.nengo.tests.test_connection.test_eval_points_scaling[True-0.5-True] ____

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, sample = True
radius = 0.5, seed = 589546462
rng = <mtrand.RandomState object at 0x7fd286a52fc0>, scale = True

    @pytest.mark.parametrize('sample', [False, True])
    @pytest.mark.parametrize('radius', [0.5, 1., 1.5])
    @pytest.mark.parametrize('scale', [False, True])
    def test_eval_points_scaling(Simulator, sample, radius, seed, rng, scale):
        eval_points = UniformHypersphere()
        if sample:
            eval_points = eval_points.sample(500, 3, rng=rng)

        model = nengo.Network(seed=seed)
        with model:
            a = nengo.Ensemble(1, 3, radius=radius)
            b = nengo.Ensemble(1, 3)
            con = nengo.Connection(a, b, eval_points=eval_points,
                                   scale_eval_points=scale)

>       sim = Simulator(model)

../nengo/nengo/tests/test_connection.py:668:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x59b8790>
size = 196, tag = 1, x = 3, y = 4, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 196 bytes of SDRAM on chip (3, 4). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
____________ test.nengo.tests.test_ensemble.test_constant_scalar[nl0] ____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x6293790>, seed = 1695718554

    def test_constant_scalar(Simulator, nl, plt, seed):
        """A Network that represents a constant value."""
        N = 30
        val = 0.5

        m = nengo.Network(seed=seed)
        with m:
            m.config[nengo.Ensemble].neuron_type = nl()
            input = nengo.Node(output=val, label='input')
            A = nengo.Ensemble(N, 1)
            nengo.Connection(input, A)
            in_p = nengo.Probe(input, 'output')
            A_p = nengo.Probe(A, 'decoded_output', synapse=0.05)

>       sim = Simulator(m)

../nengo/nengo/tests/test_ensemble.py:68:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x6293050>
size = 40112, tag = 2, x = 3, y = 4, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 40112 bytes of SDRAM on chip (3, 4). Insufficient memory available or tag 2 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
____________ test.nengo.tests.test_ensemble.test_constant_vector[nl0] ____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x6704910>, seed = 376769064

    def test_constant_vector(Simulator, nl, plt, seed):
        """A network that represents a constant 3D vector."""
        N = 30
        vals = [0.6, 0.1, -0.5]

        m = nengo.Network(seed=seed)
        with m:
            m.config[nengo.Ensemble].neuron_type = nl()
            input = nengo.Node(output=vals)
            A = nengo.Ensemble(N * len(vals), len(vals))
            nengo.Connection(input, A)
            in_p = nengo.Probe(input, 'output')
            A_p = nengo.Probe(A, 'decoded_output', synapse=0.05)

        sim = Simulator(m)
        sim.run(0.3)

        t = sim.trange()
        plt.plot(t, sim.data[in_p], label='Input')
        plt.plot(t, sim.data[A_p], label='Neuron approximation, pstc=0.05')
        plt.legend(loc='best', fontsize='small')
        plt.xlim(right=t[-1])

>       assert np.allclose(sim.data[in_p][-10:], vals, atol=.1, rtol=.01)
E       assert <function allclose at 0x26b8b90>(array([[ 0.6000061,  0.1000061,  0.       ],\n       [ 0.6000061,  0.1000061,  ...6000061,  0.1000061,  0.       ],\n       [ 0.       ,  0.       ,  0.       ]]), [0.6, 0.1, -0.5], atol=0.1, rtol=0.01)
E        +  where <function allclose at 0x26b8b90> = np.allclose

../nengo/nengo/tests/test_ensemble.py:105: AssertionError
________________ test.nengo.tests.test_ensemble.test_scalar[nl0] _________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x603bd50>, seed = 1914932375

    def test_scalar(Simulator, nl, plt, seed):
        """A network that represents sin(t)."""
        N = 40
        f = lambda t: np.sin(2 * np.pi * t)

        m = nengo.Network(label='test_scalar', seed=seed)
        with m:
            m.config[nengo.Ensemble].neuron_type = nl()
            input = nengo.Node(output=f)
            A = nengo.Ensemble(N, 1, label='A')
            nengo.Connection(input, A)
            in_p = nengo.Probe(input, 'output')
            A_p = nengo.Probe(A, 'decoded_output', synapse=0.02)

        sim = Simulator(m)
        sim.run(1.0)
        t = sim.trange()
        target = f(t)

>       assert allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5)
E       assert allclose(array([ 0.001,  0.002,  0.003,  0.004,  0.005,  0.006,  0.007,  0.008,\n       ... 0.992,\n        0.993,  0.994,  0.995,  0.996,  0.997,  0.998,  0.999,  1.   ]), array([  6.28314397e-03,   1.25660399e-02,   1.88484397e-02,\n         2.513009... -1.88484397e-02,  -1.25660399e-02,  -6.28314397e-03,\n        -2.44929360e-16]), array([[ 0.        ],\n       [ 0.00698853],\n       [ 0.01391602],\n       [ 0.0...0.02423096],\n       [-0.01602173],\n       [-0.01116943],\n       [-0.01116943]]), rtol=0.001, atol=1e-05)

../nengo/nengo/tests/test_ensemble.py:128: AssertionError
________________ test.nengo.tests.test_ensemble.test_vector[nl0] _________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x5d81250>, seed = 110200972

    def test_vector(Simulator, nl, plt, seed):
        """A network that represents sin(t), cos(t), cos(t)**2."""
        N = 100
        f = lambda t: [np.sin(6.3*t), np.cos(6.3*t), np.cos(6.3*t)**2]

        m = nengo.Network(label='test_vector', seed=seed)
        with m:
            m.config[nengo.Ensemble].neuron_type = nl()
            input = nengo.Node(output=f)
            A = nengo.Ensemble(N * 3, 3, radius=1.5)
            nengo.Connection(input, A)
            in_p = nengo.Probe(input)
            A_p = nengo.Probe(A, synapse=0.03)

        sim = Simulator(m)
        sim.run(1.0)
        t = sim.trange()
        target = np.vstack(f(t)).T

>       assert allclose(t, target, sim.data[in_p], rtol=1e-3, atol=1e-5)
E       assert allclose(array([ 0.001,  0.002,  0.003,  0.004,  0.005,  0.006,  0.007,  0.008,\n       ... 0.992,\n        0.993,  0.994,  0.995,  0.996,  0.997,  0.998,  0.999,  1.   ]), array([[ 0.00629996,  0.99998016,  0.99996031],\n       [ 0.01259967,  0.999920...5 ,  0.99994472,  0.99988945],\n       [ 0.0168139 ,  0.99985864,  0.99971729]]), array([[  3.26538086e-03,   0.00000000e+00,   0.00000000e+00],\n       [  9.429....00000000e+00],\n       [  4.54711914e-03,   1.00000000e+00,   9.99969482e-01]]), rtol=0.001, atol=1e-05)

../nengo/nengo/tests/test_ensemble.py:151: AssertionError
_________ test.nengo.tests.test_neurons.test_dt_dependence[nl_nodirect0] _________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl_nodirect = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x551c490>, seed = 1928857610
rng = <mtrand.RandomState object at 0x5995330>

    def test_dt_dependence(Simulator, nl_nodirect, plt, seed, rng):
        """Neurons should not wildly change with different dt."""
        with nengo.Network(seed=seed) as m:
            m.config[nengo.Ensemble].neuron_type = nl_nodirect()
            u = nengo.Node(output=WhiteSignal(0.1, 5), size_out=2)
            pre = nengo.Ensemble(60, dimensions=2)
            square = nengo.Ensemble(60, dimensions=2)
            nengo.Connection(u, pre)
            nengo.Connection(pre, square, function=lambda x: x ** 2)

            activity_p = nengo.Probe(square.neurons, synapse=.05,
                                     sample_every=0.001)
            out_p = nengo.Probe(square, synapse=.05, sample_every=0.001)

        activity_data = []
        out_data = []
        dts = (0.0001, 0.001)
        colors = ('b', 'g', 'r')
        for c, dt in zip(colors, dts):
            sim = Simulator(m, dt=dt, seed=seed+1)
            sim.run(0.1)
            t = sim.trange(dt=0.001)
            activity_data.append(sim.data[activity_p])
            out_data.append(sim.data[out_p])
            plt.subplot(2, 1, 1)
            plt.plot(t, sim.data[out_p], c=c)
            plt.subplot(2, 1, 2)
            # Just plot 5 neurons
            plt.plot(t, sim.data[activity_p][..., :5], c=c)

        plt.subplot(2, 1, 1)
        plt.xlim(right=t[-1])
        plt.ylabel("Decoded output")
        plt.subplot(2, 1, 2)
        plt.xlim(right=t[-1])
        plt.ylabel("Neural activity")

>       assert rmse(activity_data[0], activity_data[1]) < ((1. / dt) * 0.01)
E       assert 893.21516631399254 < ((1.0 / 0.001) * 0.01)
E        +  where 893.21516631399254 = rmse(array([[ 0.,  0.,  0., ...,  0.,  0.,  0.],\n       [ 0.,  0.,  0., ...,  0.,  ...0.,  0.,  0., ...,  0.,  0.,  0.],\n       [ 0.,  0.,  0., ...,  0.,  0.,  0.]]), array([[    0.,     0.,     0., ...,     0.,     0.,     0.],\n       [    0., ...    0.,     0.],\n       [    0.,     0.,     0., ...,     0.,     0.,  1000.]]))

../nengo/nengo/tests/test_neurons.py:318: AssertionError
______________________ test.nengo.tests.test_node.test_time ______________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>

    def test_time(Simulator):
        with nengo.Network() as model:
            u = nengo.Node(output=lambda t: t)
            up = nengo.Probe(u)

        sim = Simulator(model)
        sim.run(1.0)

        t = sim.trange()
        x = sim.data[up].flatten()
>       assert np.allclose(t, x, atol=1e-7, rtol=1e-4)
E       assert <function allclose at 0x26b8b90>(array([ 0.001,  0.002,  0.003,  0.004,  0.005,  0.006,  0.007,  0.008,\n       ... 0.992,\n        0.993,  0.994,  0.995,  0.996,  0.997,  0.998,  0.999,  1.   ]), array([  4.27246094e-04,   1.58691406e-03,   2.31933594e-03,\n         3.417968...  9.96246338e-01,   9.97711182e-01,   9.98657227e-01,\n         9.98657227e-01]), atol=1e-07, rtol=0.0001)
E        +  where <function allclose at 0x26b8b90> = np.allclose

../nengo/nengo/tests/test_node.py:18: AssertionError
_____________________ test.nengo.tests.test_node.test_simple _____________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x6284390>, seed = 983431792

    def test_simple(Simulator, plt, seed):
        m = nengo.Network(seed=seed)
        with m:
            input = nengo.Node(output=lambda t: np.sin(t))
            p = nengo.Probe(input, 'output')

        sim = Simulator(m)
        runtime = 0.5
        sim.run(runtime)

        plt.plot(sim.trange(), sim.data[p], label='sin')
        plt.legend(loc='best')

        sim_t = sim.trange()
        sim_in = sim.data[p].ravel()
>       assert np.allclose(sim_in, np.sin(sim_t))
E       assert <function allclose at 0x26b8b90>(array([  3.66210938e-04,   1.43432617e-03,   2.41088867e-03,\n         3.417968...  4.76440430e-01,   4.77111816e-01,\n         4.78302002e-01,   4.78302002e-01]), array([ 0.001     ,  0.002     ,  0.003     ,  0.00399999,  0.00499998,\n      ...03165,\n        0.47591138,  0.47679064,  0.47766942,  0.47854772,  0.47942554]))
E        +  where <function allclose at 0x26b8b90> = np.allclose
E        +  and   array([ 0.001     ,  0.002     ,  0.003     ,  0.00399999,  0.00499998,\n      ...03165,\n        0.47591138,  0.47679064,  0.47766942,  0.47854772,  0.47942554]) = <ufunc 'sin'>(array([ 0.001,  0.002,  0.003,  0.004,  0.005,  0.006,  0.007,  0.008,\n       ... 0.492,  0.493,  0.494,  0.495,  0.496,\n        0.497,  0.498,  0.499,  0.5  ]))
E        +    where <ufunc 'sin'> = np.sin

../nengo/nengo/tests/test_node.py:36: AssertionError
___________________ test.nengo.tests.test_node.test_connected ____________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x5218350>, seed = 1252681197

    def test_connected(Simulator, plt, seed):
        m = nengo.Network(seed=seed)
        with m:
            input = nengo.Node(output=lambda t: np.sin(t), label='input')
            output = nengo.Node(output=lambda t, x: np.square(x),
                                size_in=1,
                                label='output')
            nengo.Connection(input, output, synapse=None)  # Direct connection
            p_in = nengo.Probe(input, 'output')
            p_out = nengo.Probe(output, 'output')

        sim = Simulator(m)
        runtime = 0.5
        sim.run(runtime)

        t = sim.trange()
        plt.plot(t, sim.data[p_in], label='sin')
        plt.plot(t, sim.data[p_out], label='sin squared')
        plt.plot(t, np.sin(t), label='ideal sin')
        plt.plot(t, np.sin(t) ** 2, label='ideal squared')
        plt.legend(loc='best')

        sim_t = sim.trange()
        sim_sin = sim.data[p_in].ravel()
        sim_sq = sim.data[p_out].ravel()
>       assert np.allclose(sim_sin, np.sin(sim_t))
E       assert <function allclose at 0x26b8b90>(array([ 0.00054932,  0.00161743,  0.00216675,  0.00317383,  0.00424194,\n      ...60938,\n        0.47509766,  0.47625732,  0.47720337,  0.47787476,  0.47787476]), array([ 0.001     ,  0.002     ,  0.003     ,  0.00399999,  0.00499998,\n      ...03165,\n        0.47591138,  0.47679064,  0.47766942,  0.47854772,  0.47942554]))
E        +  where <function allclose at 0x26b8b90> = np.allclose
E        +  and   array([ 0.001     ,  0.002     ,  0.003     ,  0.00399999,  0.00499998,\n      ...03165,\n        0.47591138,  0.47679064,  0.47766942,  0.47854772,  0.47942554]) = <ufunc 'sin'>(array([ 0.001,  0.002,  0.003,  0.004,  0.005,  0.006,  0.007,  0.008,\n       ... 0.492,  0.493,  0.494,  0.495,  0.496,\n        0.497,  0.498,  0.499,  0.5  ]))
E        +    where <ufunc 'sin'> = np.sin

../nengo/nengo/tests/test_node.py:64: AssertionError
__________________ test.nengo.tests.test_node.test_passthrough ___________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x54ff450>, seed = 43790341

    def test_passthrough(Simulator, plt, seed):
        m = nengo.Network(seed=seed)
        with m:
            in1 = nengo.Node(output=lambda t: np.sin(t))
            in2 = nengo.Node(output=lambda t: t)
            passthrough = nengo.Node(size_in=1)
            out = nengo.Node(output=lambda t, x: x, size_in=1)

            nengo.Connection(in1, passthrough, synapse=None)
            nengo.Connection(in2, passthrough, synapse=None)
            nengo.Connection(passthrough, out, synapse=None)

            in1_p = nengo.Probe(in1, 'output')
            in2_p = nengo.Probe(in2, 'output')
            out_p = nengo.Probe(out, 'output')

        sim = Simulator(m)
        runtime = 0.5
        sim.run(runtime)

        plt.plot(sim.trange(), sim.data[in1_p]+sim.data[in2_p], label='in+in2')
        plt.plot(sim.trange()[:-2], sim.data[out_p][2:], label='out')
        plt.legend(loc='best')

        sim_in = sim.data[in1_p] + sim.data[in2_p]
        sim_out = sim.data[out_p]
>       assert np.allclose(sim_in, sim_out)
E       assert <function allclose at 0x26b8b90>(array([[  0.00000000e+00],\n       [  8.54492188e-04],\n       [  2.71606445e-03...     [  9.72473145e-01],\n       [  9.75799561e-01],\n       [  9.77264404e-01]]), array([[ 0.        ],\n       [ 0.        ],\n       [ 0.        ],\n       [ 0. ...0.4727478 ],\n       [ 0.47445679],\n       [ 0.47509766],\n       [ 0.47509766]]))
E        +  where <function allclose at 0x26b8b90> = np.allclose

../nengo/nengo/tests/test_node.py:94: AssertionError
_______________ test.nengo.tests.test_node.test_passthrough_filter _______________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x6703890>, seed = 1010458524

    def test_passthrough_filter(Simulator, plt, seed):
        m = nengo.Network(seed=seed)
        with m:
            omega = 2 * np.pi * 5
            u = nengo.Node(output=lambda t: np.sin(omega * t))
            passthrough = nengo.Node(size_in=1)
            v = nengo.Node(output=lambda t, x: x, size_in=1)

            synapse = 0.3
            nengo.Connection(u, passthrough, synapse=None)
            nengo.Connection(passthrough, v, synapse=synapse)

            up = nengo.Probe(u)
            vp = nengo.Probe(v)

        dt = 0.001
        sim = Simulator(m, dt=dt)
        sim.run(1.0)

        t = sim.trange()
        x = sim.data[up]
        y = nengo.synapses.filt(x, synapse, dt=dt)
        z = sim.data[vp]

        plt.plot(t, x)
        plt.plot(t, y)
        plt.plot(t, z)

>       assert np.allclose(y[:-1], z[1:], atol=1e-7, rtol=1e-4)
E       assert <function allclose at 0x26b8b90>(array([[  3.96068036e-06],\n       [  1.61765379e-04],\n       [  4.03539452e-04...     [ -1.01869558e-01],\n       [ -1.01828726e-01],\n       [ -1.01698458e-01]]), array([[  0.00000000e+00],\n       [  0.00000000e+00],\n       [  6.10351562e-05...     [ -1.06567383e-01],\n       [ -1.06567383e-01],\n       [ -1.06567383e-01]]), atol=1e-07, rtol=0.0001)
E        +  where <function allclose at 0x26b8b90> = np.allclose

../nengo/nengo/tests/test_node.py:125: AssertionError
____________________ test.nengo.tests.test_node.test_circular ____________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, seed = 979991316

    def test_circular(Simulator, seed):
        m = nengo.Network(seed=seed)
        with m:
            a = nengo.Node(output=lambda t, x: x+1, size_in=1)
            b = nengo.Node(output=lambda t, x: x+1, size_in=1)
            nengo.Connection(a, b, synapse=0)
            nengo.Connection(b, a, synapse=0)

            a_p = nengo.Probe(a, 'output')
            b_p = nengo.Probe(b, 'output')

        sim = Simulator(m)
        runtime = 0.5
        sim.run(runtime)

>       assert np.allclose(sim.data[a_p], sim.data[b_p])
E       assert <function allclose at 0x26b8b90>(array([[   1.],\n       [   3.],\n       [   5.],\n       [   6.],\n       [   8.]...      [ 833.],\n       [ 834.],\n       [ 836.],\n       [ 837.],\n       [ 837.]]), array([[   1.],\n       [   3.],\n       [   5.],\n       [   7.],\n       [   7.]...      [ 833.],\n       [ 834.],\n       [ 836.],\n       [ 837.],\n       [ 837.]]))
E        +  where <function allclose at 0x26b8b90> = np.allclose

../nengo/nengo/tests/test_node.py:143: AssertionError
______________________ test.nengo.tests.test_probe.test_dts ______________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, seed = 456144064
rng = <mtrand.RandomState object at 0x5995498>

    def test_dts(Simulator, seed, rng):
        """Test probes with different dts and runtimes"""

        for i in range(100):
            dt = rng.uniform(0.001, 0.1)  # simulator dt
            dt2 = rng.uniform(dt, 0.15)   # probe dt
            tend = rng.uniform(0.2, 0.3)  # simulator runtime

            with nengo.Network(seed=seed) as model:
                a = nengo.Node(output=0)
                ap = nengo.Probe(a, sample_every=dt2)

>           sim = Simulator(model, dt=dt)

../nengo/nengo/tests/test_probe.py:44:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x59a2990>
size = 876, tag = 1, x = 3, y = 4, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 876 bytes of SDRAM on chip (3, 4). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
________________ test.nengo.tests.test_processes.test_brownnoise _________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, seed = 1047320426
plt = <nengo.utils.testing.Mock object at 0x551af10>

    def test_brownnoise(Simulator, seed, plt):
        d = 5000
        t = 0.5
        std = 1.5
        process = BrownNoise(dist=Gaussian(0, std))
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

>       sim = Simulator(model, seed=seed)

../nengo/nengo/tests/test_processes.py:42:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:130: in __init__
    self.netlist.place_and_route(machine)
nengo_spinnaker/netlist.py:223: in place_and_route
    machine, constraints, **place_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/place_and_route/place/sa.py:579: in place
    machine, random)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

movable_vertices = [<nengo_spinnaker.netlist.VertexSlice object at 0x7201d90>, <nengo_spinnaker.netlist.VertexSlice object at 0x71f2c90>,...ngo_spinnaker.netlist.VertexSlice object at 0x71f4a50>, <nengo_spinnaker.netlist.VertexSlice object at 0x7201a90>, ...]
vertices_resources = {<nengo_spinnaker.netlist.Vertex object at 0x64bfc90>: {Cores: 1, SDRAM: 200000112}, <nengo_spinnaker.netlist.VertexSl...: {Cores: 1, SDRAM: 800080}, <nengo_spinnaker.netlist.VertexSlice object at 0x71f2110>: {Cores: 1, SDRAM: 800080}, ...}
machine = <rig.machine.Machine object at 0x6219d50>
random = <module 'random' from '/usr/lib/python2.7/random.pyc'>

    def _initial_placement(movable_vertices, vertices_resources, machine, random):
        """For internal use. Produces a random, sequential initial placement,
        updating the resource availabilities of every core in the supplied machine.

        Parameters
        ----------
        movable_vertices : [vertex, ...]
            A list of the vertices to be given a random initial placement.
        vertices_resources : {vertex: {resource: value, ...}, ...}
        machine : :py:class:`rig.machine.Machine`
            A machine object describing the machine into which the vertices should
            be placed.

            All chips hosting fixed vertices should have a chip_resource_exceptions
            entry which accounts for the allocated resources.

            When this function returns, the machine.chip_resource_exceptions will
            be updated to account for the resources consumed by the initial
            placement of movable vertices.
        random : :py:class`random.Random`
            The random number generator to use

        Returns
        -------
        {vertex: (x, y), ...}
            For all movable_vertices.

        Raises
        ------
        InsufficientResourceError
        InvalidConstraintError
        """
        # Initially fill chips in the system in a random order
        locations = list(machine)
        random.shuffle(locations)
        location_iter = iter(locations)

        # Greedily place the vertices in a random order
        random.shuffle(movable_vertices)
        vertex_iter = iter(movable_vertices)

        placement = {}
        try:
            location = next(location_iter)
        except StopIteration:
            raise InsufficientResourceError("No working chips in system.")
        while True:
            # Get a vertex to place
            try:
                vertex = next(vertex_iter)
            except StopIteration:
                # All vertices have been placed
                break

            # Advance through the set of available locations until we find a chip
            # where the vertex fits
            while True:
                resources_if_placed = subtract_resources(
                    machine[location], vertices_resources[vertex])

                if overallocated(resources_if_placed):
                    # The vertex won't fit on this chip, move onto the next chip
                    try:
                        location = next(location_iter)
                        continue
                    except StopIteration:
                        raise InsufficientResourceError(
                            "Ran out of chips while attempting to place vertex "
>                           "{}".format(vertex))
E                       InsufficientResourceError: Ran out of chips while attempting to place vertex <nengo_spinnaker.netlist.Vertex object at 0x64bfc90>

/usr/local/lib/python2.7/dist-packages/rig/place_and_route/place/sa.py:97: InsufficientResourceError
_________ test.nengo.tests.test_processes.test_gaussian_whitenoise[0.5] __________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, rms = 0.5
seed = 1247161810, plt = <nengo.utils.testing.Mock object at 0x62330d0>

    @pytest.mark.parametrize('rms', [0.5, 1, 100])
    def test_gaussian_whitenoise(Simulator, rms, seed, plt):
        d = 500
        process = WhiteNoise(Gaussian(0., rms), scale=False)
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

>       sim = Simulator(model, seed=seed)

../nengo/nengo/tests/test_processes.py:78:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x6233450>
size = 800080, tag = 1, x = 3, y = 4, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 800080 bytes of SDRAM on chip (3, 4). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
__________ test.nengo.tests.test_processes.test_gaussian_whitenoise[1] ___________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, rms = 1
seed = 1247161810, plt = <nengo.utils.testing.Mock object at 0x622e290>

    @pytest.mark.parametrize('rms', [0.5, 1, 100])
    def test_gaussian_whitenoise(Simulator, rms, seed, plt):
        d = 500
        process = WhiteNoise(Gaussian(0., rms), scale=False)
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

        sim = Simulator(model, seed=seed)
        sim.run(0.3)
        values = sim.data[up]
        freq, val_psd = psd(values, dt=sim.dt)

        trange = sim.trange()
        plt.subplot(2, 1, 1)
        plt.title("First two dimensions of white noise process, rms=%.1f" % rms)
        plt.plot(trange, values[:, :2])
        plt.xlim(right=trange[-1])
        plt.subplot(2, 1, 2)
        plt.title("Power spectrum")
        plt.plot(freq, val_psd, drawstyle='steps')

        val_rms = npext.rms(values, axis=0)
>       assert np.allclose(val_rms.mean(), rms, rtol=0.02)
E       assert <function allclose at 0x26b8b90>(0.7203976440429688, 1, rtol=0.02)
E        +  where <function allclose at 0x26b8b90> = np.allclose
E        +  and   0.7203976440429688 = <built-in method mean of numpy.ndarray object at 0x5ca96c0>()
E        +    where <built-in method mean of numpy.ndarray object at 0x5ca96c0> = array([  1.86849976e+00,   5.46966553e-01,   9.63256836e-01,\n         1.187927...  3.39050293e-01,   8.63830566e-01,\n         1.32141113e-01,   3.58276367e-02]).mean

../nengo/nengo/tests/test_processes.py:93: AssertionError
_________ test.nengo.tests.test_processes.test_gaussian_whitenoise[100] __________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, rms = 100
seed = 1247161810, plt = <nengo.utils.testing.Mock object at 0x623bb50>

    @pytest.mark.parametrize('rms', [0.5, 1, 100])
    def test_gaussian_whitenoise(Simulator, rms, seed, plt):
        d = 500
        process = WhiteNoise(Gaussian(0., rms), scale=False)
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

>       sim = Simulator(model, seed=seed)

../nengo/nengo/tests/test_processes.py:78:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x623be10>
size = 800080, tag = 1, x = 3, y = 3, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 800080 bytes of SDRAM on chip (3, 3). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
___________ test.nengo.tests.test_processes.test_whitesignal_rms[0.5] ____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, rms = 0.5
seed = 1815311383, plt = <nengo.utils.testing.Mock object at 0x8111510>

    @pytest.mark.parametrize('rms', [0.5, 1, 100])
    def test_whitesignal_rms(Simulator, rms, seed, plt):
        t = 1.
        d = 500
        process = WhiteSignal(t, rms=rms)
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

>       sim = Simulator(model, seed=seed)

../nengo/nengo/tests/test_processes.py:106:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x621e8d0>
size = 800080, tag = 1, x = 3, y = 2, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 800080 bytes of SDRAM on chip (3, 2). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
____________ test.nengo.tests.test_processes.test_whitesignal_rms[1] _____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, rms = 1
seed = 1815311383, plt = <nengo.utils.testing.Mock object at 0x5680290>

    @pytest.mark.parametrize('rms', [0.5, 1, 100])
    def test_whitesignal_rms(Simulator, rms, seed, plt):
        t = 1.
        d = 500
        process = WhiteSignal(t, rms=rms)
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

>       sim = Simulator(model, seed=seed)

../nengo/nengo/tests/test_processes.py:106:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x5680410>
size = 800080, tag = 4, x = 4, y = 2, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 800080 bytes of SDRAM on chip (4, 2). Insufficient memory available or tag 4 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
___________ test.nengo.tests.test_processes.test_whitesignal_rms[100] ____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, rms = 100
seed = 1815311383, plt = <nengo.utils.testing.Mock object at 0x6701290>

    @pytest.mark.parametrize('rms', [0.5, 1, 100])
    def test_whitesignal_rms(Simulator, rms, seed, plt):
        t = 1.
        d = 500
        process = WhiteSignal(t, rms=rms)
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

>       sim = Simulator(model, seed=seed)

../nengo/nengo/tests/test_processes.py:106:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x5680dd0>
size = 800080, tag = 1, x = 3, y = 4, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 800080 bytes of SDRAM on chip (3, 4). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
____________ test.nengo.tests.test_processes.test_whitesignal_high[5] ____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, high = 5
seed = 440916656, plt = <nengo.utils.testing.Mock object at 0x68c62d0>

    @pytest.mark.parametrize('high', [5, 50])
    def test_whitesignal_high(Simulator, high, seed, plt):
        t = 1.
        rms = 0.5
        d = 500
        process = WhiteSignal(t, high, rms=rms)
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

>       sim = Simulator(model, seed=seed)

../nengo/nengo/tests/test_processes.py:134:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x5662950>
size = 800080, tag = 1, x = 4, y = 3, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 800080 bytes of SDRAM on chip (4, 3). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
___________ test.nengo.tests.test_processes.test_whitesignal_high[50] ____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, high = 50
seed = 440916656, plt = <nengo.utils.testing.Mock object at 0x59bee10>

    @pytest.mark.parametrize('high', [5, 50])
    def test_whitesignal_high(Simulator, high, seed, plt):
        t = 1.
        rms = 0.5
        d = 500
        process = WhiteSignal(t, high, rms=rms)
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

>       sim = Simulator(model, seed=seed)

../nengo/nengo/tests/test_processes.py:134:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x51de3d0>
size = 800080, tag = 1, x = 4, y = 3, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 800080 bytes of SDRAM on chip (4, 3). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
______________ test.nengo.tests.test_processes.test_whitesignal_dt _______________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>, seed = 1763426742
plt = <nengo.utils.testing.Mock object at 0x7f48210>

    def test_whitesignal_dt(Simulator, seed, plt):
        t = 1.
        dt = 0.01
        high = 10
        rms = 0.5
        d = 500
        process = WhiteSignal(t, high, rms=rms)
        with nengo.Network() as model:
            u = nengo.Node(process, size_out=d)
            up = nengo.Probe(u)

>       sim = Simulator(model, seed=seed, dt=dt)

../nengo/nengo/tests/test_processes.py:165:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x7f48e90>
size = 80080, tag = 1, x = 4, y = 3, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 80080 bytes of SDRAM on chip (4, 3). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
____________ test.nengo.tests.test_simulator.test_trange_with_probes _____________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>

    def test_trange_with_probes(Simulator):
        dt = 1e-3
        m = nengo.Network()
        periods = dt * np.arange(1, 21)
        with m:
            u = nengo.Node(output=np.sin)
            probes = [nengo.Probe(u, sample_every=p, synapse=5*p) for p in periods]

>       sim = Simulator(m, dt=dt)

../nengo/nengo/tests/test_simulator.py:42:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x54fb790>
size = 24, tag = 2, x = 4, y = 3, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 24 bytes of SDRAM on chip (4, 3). Insufficient memory available or tag 2 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
__________________ test.nengo.tests.test_synapses.test_lowpass ___________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x5233e10>, seed = 2101635706

    def test_lowpass(Simulator, plt, seed):
        dt = 1e-3
        tau = 0.03

>       t, x, yhat = run_synapse(Simulator, seed, Lowpass(tau), dt=dt)

../nengo/nengo/tests/test_synapses.py:36:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../nengo/nengo/tests/test_synapses.py:26: in run_synapse
    sim = Simulator(model, dt=dt, seed=seed+1)
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x5244dd0>
size = 40112, tag = 1, x = 5, y = 4, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 40112 bytes of SDRAM on chip (5, 4). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
__________________ test.nengo.tests.test_synapses.test_decoders __________________

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
plt = <nengo.utils.testing.Mock object at 0x626e390>, seed = 1173649733

    def test_decoders(Simulator, plt, seed):
        dt = 1e-3
        tau = 0.01

        t, x, yhat = run_synapse(
>           Simulator, seed, Lowpass(tau), dt=dt, n_neurons=100)

../nengo/nengo/tests/test_synapses.py:76:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../nengo/nengo/tests/test_synapses.py:26: in run_synapse
    sim = Simulator(model, dt=dt, seed=seed+1)
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x626e0d0>
size = 2176, tag = 1, x = 4, y = 3, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 2176 bytes of SDRAM on chip (4, 3). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
_ test.nengo.utils.tests.test_connection.test_target_function[nl_nodirect0-1-1] __

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl_nodirect = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x68c23d0>, dimensions = 1, radius = 1
seed = 1996101602, rng = <mtrand.RandomState object at 0x5995750>

    @pytest.mark.parametrize("dimensions", [1, 4])
    @pytest.mark.parametrize("radius", [1, 2.0])
    def test_target_function(Simulator, nl_nodirect, plt, dimensions, radius,
                             seed, rng):
        eval_points = UniformHypersphere().sample(1000, dimensions, rng=rng)
        eval_points *= radius
        f = lambda x: x ** 2
        targets = f(eval_points)

        model = nengo.Network(seed=seed)
        with model:
            model.config[nengo.Ensemble].neuron_type = nl_nodirect()
            inp = nengo.Node(lambda t: np.sin(t * 2 * np.pi) * radius)
            ens1 = nengo.Ensemble(40 * dimensions, dimensions, radius=radius)
            n1 = nengo.Node(size_in=dimensions)
            n2 = nengo.Node(size_in=dimensions)
            transform = np.linspace(1, -1, num=dimensions).reshape(-1, 1)
            nengo.Connection(inp, ens1, transform=transform)
            # pass in eval_points and targets
            nengo.Connection(ens1, n1, **target_function(eval_points, targets))
            # same, but let the builder apply f
            nengo.Connection(ens1, n2, function=f)
            probe1 = nengo.Probe(n1, synapse=0.03)
            probe2 = nengo.Probe(n2, synapse=0.03)

>       sim = Simulator(model)

../nengo/nengo/utils/tests/test_connection.py:36:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x6219690>
size = 24, tag = 1, x = 3, y = 3, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 24 bytes of SDRAM on chip (3, 3). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
 test.nengo.utils.tests.test_connection.test_target_function[nl_nodirect0-2.0-1] _

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl_nodirect = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x64cbb50>, dimensions = 1, radius = 2.0
seed = 1996101602, rng = <mtrand.RandomState object at 0x5995330>

    @pytest.mark.parametrize("dimensions", [1, 4])
    @pytest.mark.parametrize("radius", [1, 2.0])
    def test_target_function(Simulator, nl_nodirect, plt, dimensions, radius,
                             seed, rng):
        eval_points = UniformHypersphere().sample(1000, dimensions, rng=rng)
        eval_points *= radius
        f = lambda x: x ** 2
        targets = f(eval_points)

        model = nengo.Network(seed=seed)
        with model:
            model.config[nengo.Ensemble].neuron_type = nl_nodirect()
            inp = nengo.Node(lambda t: np.sin(t * 2 * np.pi) * radius)
            ens1 = nengo.Ensemble(40 * dimensions, dimensions, radius=radius)
            n1 = nengo.Node(size_in=dimensions)
            n2 = nengo.Node(size_in=dimensions)
            transform = np.linspace(1, -1, num=dimensions).reshape(-1, 1)
            nengo.Connection(inp, ens1, transform=transform)
            # pass in eval_points and targets
            nengo.Connection(ens1, n1, **target_function(eval_points, targets))
            # same, but let the builder apply f
            nengo.Connection(ens1, n2, function=f)
            probe1 = nengo.Probe(n1, synapse=0.03)
            probe2 = nengo.Probe(n2, synapse=0.03)

>       sim = Simulator(model)

../nengo/nengo/utils/tests/test_connection.py:36:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x7f4b5d0>
size = 984, tag = 1, x = 2, y = 3, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 984 bytes of SDRAM on chip (2, 3). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
 test.nengo.utils.tests.test_connection.test_target_function[nl_nodirect0-2.0-4] _

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl_nodirect = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x66fc490>, dimensions = 4, radius = 2.0
seed = 1996101602, rng = <mtrand.RandomState object at 0x59953d8>

    @pytest.mark.parametrize("dimensions", [1, 4])
    @pytest.mark.parametrize("radius", [1, 2.0])
    def test_target_function(Simulator, nl_nodirect, plt, dimensions, radius,
                             seed, rng):
        eval_points = UniformHypersphere().sample(1000, dimensions, rng=rng)
        eval_points *= radius
        f = lambda x: x ** 2
        targets = f(eval_points)

        model = nengo.Network(seed=seed)
        with model:
            model.config[nengo.Ensemble].neuron_type = nl_nodirect()
            inp = nengo.Node(lambda t: np.sin(t * 2 * np.pi) * radius)
            ens1 = nengo.Ensemble(40 * dimensions, dimensions, radius=radius)
            n1 = nengo.Node(size_in=dimensions)
            n2 = nengo.Node(size_in=dimensions)
            transform = np.linspace(1, -1, num=dimensions).reshape(-1, 1)
            nengo.Connection(inp, ens1, transform=transform)
            # pass in eval_points and targets
            nengo.Connection(ens1, n1, **target_function(eval_points, targets))
            # same, but let the builder apply f
            nengo.Connection(ens1, n2, function=f)
            probe1 = nengo.Probe(n1, synapse=0.03)
            probe2 = nengo.Probe(n2, synapse=0.03)

>       sim = Simulator(model)

../nengo/nengo/utils/tests/test_connection.py:36:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x54e7950>
size = 172, tag = 1, x = 5, y = 4, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 172 bytes of SDRAM on chip (5, 4). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
____ test.nengo.utils.tests.test_ensemble.test_response_curves[nl_nodirect0] _____

Simulator = <class 'nengo_spinnaker.simulator.Simulator'>
nl_nodirect = <class 'nengo.neurons.LIF'>
plt = <nengo.utils.testing.Mock object at 0x6233650>, seed = 119844955

    def test_response_curves(Simulator, nl_nodirect, plt, seed):
        max_rate = 400
        model = nengo.Network(seed=seed)
        with model:
            ens = nengo.Ensemble(
                10, dimensions=10, neuron_type=nl_nodirect(), radius=1.5,
                max_rates=Uniform(200, max_rate))
>       sim = Simulator(model)

../nengo/nengo/utils/tests/test_ensemble.py:79:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nengo_spinnaker/simulator.py:142: in __init__
    self.netlist.load_application(self.controller)
nengo_spinnaker/netlist.py:259: in load_application
    controller, self.placements, self.allocations
/usr/local/lib/python2.7/dist-packages/rig/machine_control/utils.py:88: in sdram_alloc_for_vertices
    size, tag, x=x, y=y, buffer_size=buffer_size
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:722: in sdram_alloc_as_filelike
    start_address = self.sdram_alloc(size, tag, x, y, app_id)
/usr/local/lib/python2.7/dist-packages/rig/utils/contexts.py:172: in f_
    return f(self, *args, **new_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <rig.machine_control.machine_controller.MachineController object at 0x6233810>
size = 616, tag = 1, x = 2, y = 3, app_id = 66

    @ContextMixin.use_contextual_arguments()
    def sdram_alloc(self, size, tag=0, x=Required, y=Required,
                    app_id=Required):
        """Allocate a region of SDRAM for an application.

            Requests SARK to allocate a block of SDRAM for an application. This
            allocation will be freed when the application is stopped.

            Parameters
            ----------
            size : int
                Number of bytes to attempt to allocate in SDRAM.
            tag : int
                8-bit (chip-wide) tag that can be looked up by a SpiNNaker
                application to discover the address of the allocated block.  If `0`
                then no tag is applied.

            Returns
            -------
            int
                Address of the start of the region.

            Raises
            ------
            SpiNNakerMemoryError
                If the memory cannot be allocated, the tag is already taken or it
                is invalid.
            """
        assert 0 <= tag < 256

        # Construct arg1 (app_id << 8) | op code
        arg1 = app_id << 8 | consts.AllocOperations.alloc_sdram

        # Send the packet and retrieve the address
        rv = self._send_scp(x, y, 0, SCPCommands.alloc_free, arg1, size, tag)
        if rv.arg1 == 0:
            # Allocation failed
>           raise SpiNNakerMemoryError(size, x, y, tag)
E           SpiNNakerMemoryError: Failed to allocate 616 bytes of SDRAM on chip (2, 3). Insufficient memory available or tag 1 already in use.

/usr/local/lib/python2.7/dist-packages/rig/machine_control/machine_controller.py:692: SpiNNakerMemoryError
==== 38 failed, 78 passed, 8 skipped, 60 xfailed, 2 xpassed in 372.86 seconds ====
```
