### PR TITLE
Enable timescaling

### DIFF
--- a/nengo_spinnaker/operators/lif.py
+++ b/nengo_spinnaker/operators/lif.py
@@ -186,10 +186,14 @@ class EnsembleLIF(object):
             return (196 + 43*self.ensemble.size_in + 45 + 126*size_out +
                     69.45*n_neurons + 8.81*n_neurons*self.ensemble.size_in)
 
+        # The number of cycles is 200MHz * the machine timestep; or 200 * the
+        # machine timestep in microseconds.
+        cycles = 200 * model.machine_timestep
+
         self.vertices = list()
         sdram_constraint = partition.Constraint(8*2**20)  # Max 8MiB
         dtcm_constraint = partition.Constraint(64*2**10, .75)  # 75% of 64KiB
-        cpu_constraint = partition.Constraint(200000, .8)  # 80% of 200k cycles
+        cpu_constraint = partition.Constraint(cycles, .8)  # 80% of the cycles
         constraints = {
             sdram_constraint: lambda s: regions.utils.sizeof_regions(
                 self.regions, s),

--- a/regression-tests/test_time_scaling.py
+++ b/regression-tests/test_time_scaling.py
@@ -1,0 +1,39 @@
+import nengo
+import nengo_spinnaker
+import numpy as np
+import pytest
+import time
+
+
+@pytest.mark.parametrize("timescale", [0.5, 0.1]) # Half-time, 10th time
+@pytest.mark.parametrize("f_of_t", [True, False])
+def test_time_scaling(timescale, f_of_t):
+    """Test that for various time-scales the model results in the same
+    behaviour but takes different times to compute.
+    """
+    # Create a model to test
+    with nengo.Network() as model:
+        inp = nengo.Node(lambda t: -0.75 if t < 1.0 else .25)
+        ens = nengo.Ensemble(100, 1)
+        nengo.Connection(inp, ens)
+        p = nengo.Probe(ens, synapse=0.01)
+
+    # Mark function of time Node if necessary
+    if f_of_t:
+        nengo_spinnaker.add_spinnaker_params(model.config)
+        model.config[inp].function_of_time = True
+
+    # Perform the simulation
+    runtime = 2.0
+    sim = nengo_spinnaker.Simulator(model, timescale=timescale)
+    with sim:
+        start = time.time()
+        sim.run(runtime)
+        duration = time.time() - start
+
+    # Assert that the output is reasonable
+    assert np.allclose(sim.data[p][100:900], -0.75, atol=1e-1)
+    assert np.allclose(sim.data[p][1500:1900], +0.25, atol=1e-1)
+
+    # Assert that the simulation took a reasonable amount of time
+    assert 0.8 <= (timescale * duration) / runtime <= 1.2


### PR DESCRIPTION
Adds a new timescaling parameter to the Simulator.  This can be used to speed a simulation up or slow it down.  Tests are added to ensure that this works as expected with a connected SpiNNaker machine.
