### PR TITLE
Filter signals when making the netlist

### DIFF
--- a/nengo_spinnaker/builder/builder.py
+++ b/nengo_spinnaker/builder/builder.py
@@ -344,7 +344,8 @@ class Model(object):
 
         # Construct nets from the signals
         nets = list()
-        for signal in self.connection_map.get_signals():
+        for signal, transmission_parameters in \
+                self.connection_map.get_signals():
             # Get the source and sink vertices
             sources = operator_vertices[signal.source]
             if not isinstance(sources, collections.Iterable):
@@ -352,10 +353,29 @@ class Model(object):
 
             sinks = collections_ext.flatinsertionlist()
             for sink in signal.sinks:
-                sinks.append(operator_vertices[sink])
+                # Get all the sink vertices
+                sink_vertices = operator_vertices[sink]
+                if not isinstance(sink_vertices, collections.Iterable):
+                    sink_vertices = (sink_vertices, )
+
+                # Include any sinks which either don't have an `accepts_signal`
+                # method or return true when this is called with the signal and
+                # transmission parameters.
+                sinks.append(s for s in sink_vertices if
+                             not hasattr(s, "accepts_signal") or
+                             s.accepts_signal(signal, transmission_parameters))
 
             # Create the net(s)
             for source in sources:
+                # For each source which either doesn't have a
+                # `transmits_signal` method or returns True when this is called
+                # with the signal and transmission parameters add a new net to
+                # the netlist.
+                if (hasattr(source, "transmits_signal") and not
+                        source.transmits_signal(signal,
+                                                transmission_parameters)):
+                    continue  # No net for this source
+
                 nets.append(Net(source, list(sinks),
                             signal.weight, signal.keyspace))
 

--- a/nengo_spinnaker/builder/model.py
+++ b/nengo_spinnaker/builder/model.py
@@ -156,14 +156,14 @@ class ConnectionMap(object):
         # For each source object and set of sinks yield a new signal
         for source, port_conns in iteritems(self._connections):
             # For each connection look at the sinks and the signal parameters
-            for (sig_pars, _), par_sinks in chain(*itervalues(port_conns)):
+            for (sig_pars, transmission_pars), par_sinks in \
+                    chain(*itervalues(port_conns)):
                 # Create a signal using these parameters
-                yield Signal(
-                    source,
-                    (ps.sink_object for ps in par_sinks),  # Extract the sinks
-                    sig_pars.keyspace,
-                    sig_pars.weight
-                )
+                yield (Signal(source,
+                              (ps.sink_object for ps in par_sinks),  # Sinks
+                              sig_pars.keyspace,
+                              sig_pars.weight),
+                       transmission_pars)
 
 
 class OutputPort(enum.Enum):

--- a/tests/builder/test_model.py
+++ b/tests/builder/test_model.py
@@ -291,23 +291,26 @@ class TestConnectionMap(object):
 
         # Add the connections
         cm = model.ConnectionMap()
+        tp_a = mock.Mock(name="Transmission Parameters A")
+        tp_b = mock.Mock(name="Transmission Parameters B")
+
         cm.add_connection(
             obj_a, None, model.SignalParameters(weight=3, keyspace=ks_abc),
-            None, obj_b, None, None
+            tp_a, obj_b, None, None
         )
         cm.add_connection(
             obj_a, None, model.SignalParameters(weight=3, keyspace=ks_abc),
-            None, obj_c, None, None
+            tp_a, obj_c, None, None
         )
         cm.add_connection(
             obj_c, None, model.SignalParameters(weight=5, keyspace=ks_cb),
-            None, obj_b, None, None
+            tp_b, obj_b, None, None
         )
 
         # Get the signals, this should be a list of two signals
         signals = list(cm.get_signals())
         assert len(signals) == 2
-        for signal in signals:
+        for signal, transmission_params in signals:
             if signal.source is obj_a:
                 # Assert the sinks are correct
                 assert len(signal.sinks) == 2
@@ -319,9 +322,15 @@ class TestConnectionMap(object):
 
                 # Assert the weight is correct
                 assert signal.weight == 3
+
+                # Assert the correct paired transmission parameters are used.
+                assert transmission_params is tp_a
             else:
                 # Source should be C, sink B
                 assert signal.source is obj_c
                 assert signal.sinks == [obj_b]
                 assert signal.keyspace is ks_cb
                 assert signal.weight == 5
+
+                # Assert the correct paired transmission parameters are used.
+                assert transmission_params is tp_b


### PR DESCRIPTION
Vertices may now choose whether or not they are used as the source or
the sink for a signal.

Implementing `transmits_signal(signal_params, transmission_params)`
allows vertices to avoid being the source for a signal.  Implementing
`accepts_signal(signal_params, transmission_params)` allows signals to
avoid being the sink for a signal.
