### PR TITLE
Prune filters with no outgoing connections

### DIFF
--- a/nengo_spinnaker/builder/netlist.py
+++ b/nengo_spinnaker/builder/netlist.py
@@ -1,0 +1,14 @@
+import collections
+
+
+class netlistspec(collections.namedtuple(
+        "netlistspec", "vertices, load_function, before_simulation_function, "
+                       "after_simulation_function")):
+    """Specification of how an operator should be added to a netlist."""
+    def __new__(cls, vertices, load_function=None,
+                before_simulation_function=None,
+                after_simulation_function=None):
+        return super(netlistspec, cls).__new__(
+            cls, vertices, load_function, before_simulation_function,
+            after_simulation_function
+        )

--- a/nengo_spinnaker/operators/filter.py
+++ b/nengo_spinnaker/operators/filter.py
@@ -2,8 +2,8 @@ import numpy as np
 from rig.machine import Cores, SDRAM
 import struct
 
-from nengo_spinnaker.builder.builder import netlistspec
 from nengo_spinnaker.builder.model import InputPort, OutputPort
+from nengo_spinnaker.builder.netlist import netlistspec
 from nengo_spinnaker.regions.filters import make_filter_regions
 from .. import regions
 from nengo_spinnaker.netlist import Vertex

--- a/nengo_spinnaker/operators/lif.py
+++ b/nengo_spinnaker/operators/lif.py
@@ -13,8 +13,8 @@ import numpy as np
 from rig.machine import Cores, SDRAM
 import struct
 
-from nengo_spinnaker.builder.builder import netlistspec
 from nengo_spinnaker.builder.model import InputPort, OutputPort
+from nengo_spinnaker.builder.netlist import netlistspec
 from nengo_spinnaker.builder.ports import EnsembleInputPort
 from nengo_spinnaker.regions.filters import make_filter_regions
 from .. import regions

--- a/nengo_spinnaker/operators/sdp_receiver.py
+++ b/nengo_spinnaker/operators/sdp_receiver.py
@@ -2,8 +2,8 @@ from rig.machine import Cores, SDRAM
 import six
 import struct
 
-from nengo_spinnaker.builder.builder import netlistspec
 from nengo_spinnaker.builder.model import OutputPort
+from nengo_spinnaker.builder.netlist import netlistspec
 from nengo_spinnaker.netlist import Vertex
 from nengo_spinnaker.regions import KeyspacesRegion, KeyField, Region
 from nengo_spinnaker.regions import utils as region_utils

--- a/nengo_spinnaker/operators/sdp_transmitter.py
+++ b/nengo_spinnaker/operators/sdp_transmitter.py
@@ -1,8 +1,8 @@
 from rig.machine import Cores, SDRAM
 import struct
 
-from nengo_spinnaker.builder.builder import netlistspec
 from nengo_spinnaker.builder.model import InputPort
+from nengo_spinnaker.builder.netlist import netlistspec
 from nengo_spinnaker.netlist import Vertex
 from nengo_spinnaker.regions import Region
 from nengo_spinnaker.regions.filters import make_filter_regions

--- a/nengo_spinnaker/operators/value_sink.py
+++ b/nengo_spinnaker/operators/value_sink.py
@@ -2,8 +2,8 @@ import numpy as np
 from rig.machine import Cores, SDRAM
 import struct
 
-from nengo_spinnaker.builder.builder import netlistspec
 from nengo_spinnaker.builder.model import InputPort
+from nengo_spinnaker.builder.netlist import netlistspec
 from nengo_spinnaker import regions
 from nengo_spinnaker.regions.filters import make_filter_regions
 from nengo_spinnaker.netlist import Vertex

--- a/nengo_spinnaker/operators/value_source.py
+++ b/nengo_spinnaker/operators/value_source.py
@@ -7,8 +7,8 @@ import struct
 from nengo.processes import Process
 from nengo.utils import numpy as npext
 
-from nengo_spinnaker.builder.builder import netlistspec
 from nengo_spinnaker.builder.model import OutputPort
+from nengo_spinnaker.builder.netlist import netlistspec
 from nengo_spinnaker.netlist import VertexSlice
 from nengo_spinnaker import partition_and_cluster as partition
 from nengo_spinnaker import regions

--- a/tests/builder/test_builder.py
+++ b/tests/builder/test_builder.py
@@ -6,10 +6,12 @@ import numpy as np
 import pytest
 
 from nengo_spinnaker.builder.builder import (
-    Model, spec, ObjectPort, netlistspec, _make_signal_parameters
+    Model, spec, ObjectPort, _make_signal_parameters
 )
 from nengo_spinnaker.builder.model import SignalParameters
+from nengo_spinnaker.builder.netlist import netlistspec
 from nengo_spinnaker.netlist import Vertex, VertexSlice
+from nengo_spinnaker import operators
 
 
 # used for testing _make_signal_parameters
@@ -460,14 +462,14 @@ class TestMakeNetlist(object):
         # map.
         default_ks = mock.Mock()
         model = Model(keyspaces={"nengo": default_ks})
-        model.connection_map = mock.Mock()
-        model.connection_map.get_signals.return_value = list()
 
         # Create the netlist, ensure that this results in a call to
         # `add_default_keyspace'
-        model.make_netlist()
-        model.connection_map.add_default_keyspace.assert_called_once_with(
-            default_ks)
+        with mock.patch.object(model.connection_map,
+                               "add_default_keyspace") as f:
+            model.make_netlist()
+
+        f.assert_called_once_with(default_ks)
 
     def test_single_vertices(self):
         """Test that operators which produce single vertices work correctly and
@@ -527,6 +529,40 @@ class TestMakeNetlist(object):
         assert set(netlist.load_functions) == set([load_fn_a, load_fn_b])
         assert netlist.before_simulation_functions == [pre_fn_a]
         assert netlist.after_simulation_functions == [post_fn_a]
+
+    def test_removes_sinkless_filters(self):
+        """Test that making a netlist correctly filters out passthrough Nodes
+        with no outgoing connections.
+        """
+        # Create the first operator
+        object_a = mock.Mock(name="object A")
+        vertex_a = mock.Mock(name="vertex A")
+        load_fn_a = mock.Mock(name="load function A")
+        pre_fn_a = mock.Mock(name="pre function A")
+        post_fn_a = mock.Mock(name="post function A")
+
+        operator_a = mock.Mock(name="operator A")
+        operator_a.make_vertices.return_value = \
+            netlistspec(vertex_a, load_fn_a, pre_fn_a, post_fn_a)
+
+        # Create the second operator
+        object_b = mock.Mock(name="object B")
+        operator_b = operators.Filter(16)  # Shouldn't need building
+
+        # Create the model, add the items and add an entry to the connection
+        # map.
+        model = Model()
+        model.object_operators[object_a] = operator_a
+        model.object_operators[object_b] = operator_b
+        model.connection_map.add_connection(
+            operator_a, None, SignalParameters(), None,
+            operator_b, None, None
+        )
+        netlist = model.make_netlist(1)
+
+        # The netlist should contain vertex a and no nets
+        assert netlist.nets == list()
+        assert netlist.vertices == [vertex_a]
 
     def test_extra_operators_and_signals(self):
         """Test the operators in the extra_operators list are included when

--- a/tests/builder/test_model.py
+++ b/tests/builder/test_model.py
@@ -333,3 +333,90 @@ class TestConnectionMap(object):
 
                 # Assert the correct paired transmission parameters are used.
                 assert transmission_params is tp_b
+
+
+def test_remove_sinkless_signals():
+    """Removing sinkless signals will modify the connection map to remove any
+    signals which no-longer have any sinks.
+    """
+    # Construct a connection map containing two signals.
+    # Objects to act as sources and sinks
+    obj_a = mock.Mock(name="A")
+    obj_b = mock.Mock(name="B")
+
+    # Add the connections
+    cm = model.ConnectionMap()
+    cm.add_connection(
+        obj_a, None, model.SignalParameters(weight=1), None,
+        obj_b, None, None
+    )
+    cm.add_connection(
+        obj_b, None, model.SignalParameters(weight=2), None,
+        obj_a, None, None
+    )
+
+    # Remove the sinks from one of the connections
+    for _, sinks in cm._connections[obj_b][None]:
+        for sink in sinks:
+            sinks.remove(sink)
+
+    # Remove all the sinkless signals
+    model.remove_sinkless_signals(cm)
+
+    # Assert that only one signal remains
+    assert len(cm.get_signals_from_object(obj_a)[None]) == 1
+    assert len(cm.get_signals_from_object(obj_b)) == 0
+    assert len(list(cm.get_signals())) == 1
+
+def test_remove_sinkless_objects():
+    """Filter objects with no outgoing connections (hence sinks) can safely be
+    removed from the network.  This process should be called repeatedly as long
+    as there are filters which can be removed.
+
+    We construct the following network and then expect that all items apart
+    from A and G are removed from the connection map.
+
+                /--> C --\
+               /          \
+        A --> B            E --> F
+        |      \          /
+        |       \--> D --/
+        \-> G
+
+    The result should be a reduced connection map and a list of all objects
+    apart from A and G.
+    """
+    class G(object):
+        """Separate class to indicate the type filtering works as expected."""
+
+    # Construct the network objects
+    a = mock.Mock(name="A")
+    b = mock.Mock(name="B")
+    c = mock.Mock(name="C")
+    d = mock.Mock(name="D")
+    e = mock.Mock(name="E")
+    f = mock.Mock(name="F")
+    g = G()
+
+    # Make the connection map
+    cm = model.ConnectionMap()
+    cm.add_connection(a, None, model.SignalParameters(), None, b, None, None)
+    cm.add_connection(a, None, model.SignalParameters(), None, g, None, None)
+    cm.add_connection(b, None, model.SignalParameters(), None, c, None, None)
+    cm.add_connection(b, None, model.SignalParameters(), None, d, None, None)
+    cm.add_connection(c, None, model.SignalParameters(), None, e, None, None)
+    cm.add_connection(d, None, model.SignalParameters(), None, e, None, None)
+    cm.add_connection(e, None, model.SignalParameters(), None, f, None, None)
+
+    # Remove the sinkless filters
+    removed = model.remove_sinkless_objects(cm, mock.Mock)
+
+    # Check that the expected connection A->G still exists.
+    assert len(cm.get_signals_from_object(a)[None]) == 1
+    assert len(list(cm.get_signals())) == 1
+
+    # Assert that the removed objects list is correct
+    expected_removed = set((b, c, d, e, f))
+    for x in expected_removed:
+        assert len(cm.get_signals_from_object(x)) == 0
+    assert removed == expected_removed


### PR DESCRIPTION
Automatically prune out Filter operators which have no outgoing connections, this is equivalent to removing passthrough Nodes which do not connect to anything.

Sadly some mess was incurred in avoiding a circular import.  Some refactoring may be a good idea soon.
