### PR TITLE
Refactor `TransmissionParameters`

### DIFF
--- a/nengo_spinnaker/builder/ensemble.py
+++ b/nengo_spinnaker/builder/ensemble.py
@@ -9,6 +9,7 @@ from nengo.utils import numpy as npext
 import numpy as np
 
 from .builder import BuiltConnection, Model, ObjectPort, spec
+from .connection import EnsembleTransmissionParameters
 from .model import InputPort
 from .ports import EnsembleInputPort
 from .. import operators
@@ -137,37 +138,6 @@ def build_lif(model, ens):
     model.object_operators[ens] = operators.EnsembleLIF(ens)
 
 
-class EnsembleTransmissionParameters(object):
-    """Transmission parameters for a connection originating at an Ensemble.
-
-    Attributes
-    ----------
-    decoders : array
-        Decoders to use for the connection (including the transform).
-    """
-    def __init__(self, decoders):
-        # Copy the decoders
-        self.decoders = np.array(decoders)
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __eq__(self, other):
-        # Equal iff. the objects are of the same type
-        if type(self) is not type(other):
-            return False
-
-        # Equal iff. the decoders are the same shape
-        if self.decoders.shape != other.decoders.shape:
-            return False
-
-        # Equal iff. the decoder values are the same
-        if np.any(self.decoders != other.decoders):
-            return False
-
-        return True
-
-
 @Model.transmission_parameter_builders.register(nengo.Ensemble)
 def build_from_ensemble_connection(model, conn):
     """Build the parameters object for a connection from an Ensemble."""
@@ -198,10 +168,7 @@ def build_from_ensemble_connection(model, conn):
             np.all(transform[0, :] == transform[1:, :])):
         transform = np.array([transform[0]])
 
-    # Multiply the decoders by the transform and return this as the
-    # transmission parameters.
-    full_decoders = np.dot(transform, decoders.T).T
-    return EnsembleTransmissionParameters(full_decoders)
+    return EnsembleTransmissionParameters(decoders, transform)
 
 
 @Model.transmission_parameter_builders.register(nengo.ensemble.Neurons)

--- a/nengo_spinnaker/builder/node.py
+++ b/nengo_spinnaker/builder/node.py
@@ -5,6 +5,8 @@ import threading
 
 from nengo_spinnaker.builder.builder import ObjectPort, spec, Model
 from nengo_spinnaker.builder.model import InputPort, OutputPort
+from .connection import (PassthroughNodeTransmissionParameters,
+                         NodeTransmissionParameters)
 from nengo_spinnaker.operators import Filter, ValueSink, ValueSource
 from nengo_spinnaker.utils.config import getconfig
 
@@ -291,58 +293,6 @@ def build_node_transmission_parameters(model, conn):
                                           transform)
     else:
         return PassthroughNodeTransmissionParameters(transform)
-
-
-class PassthroughNodeTransmissionParameters(object):
-    """Parameters describing connections which originate from pass through
-    Nodes.
-    """
-    def __init__(self, transform):
-        # Store the parameters, copying the transform
-        self.transform = np.array(transform)
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __eq__(self, other):
-        # Equivalent if the same type
-        if type(self) is not type(other):
-            return False
-
-        # and the transforms are equivalent
-        if (self.transform.shape != other.transform.shape or
-                np.any(self.transform != other.transform)):
-            return False
-
-        return True
-
-
-class NodeTransmissionParameters(PassthroughNodeTransmissionParameters):
-    """Parameters describing connections which originate from Nodes."""
-    def __init__(self, pre_slice, function, transform):
-        # Store the parameters
-        super(NodeTransmissionParameters, self).__init__(transform)
-        self.pre_slice = pre_slice
-        self.function = function
-
-    def __hash__(self):
-        # Hash by ID
-        return hash(id(self))
-
-    def __eq__(self, other):
-        # Parent equivalence
-        if not super(NodeTransmissionParameters, self).__eq__(other):
-            return False
-
-        # Equivalent if the pre_slices are exactly the same
-        if self.pre_slice != other.pre_slice:
-            return False
-
-        # Equivalent if the functions are the same
-        if self.function is not other.function:
-            return False
-
-        return True
 
 
 class InputNode(nengo.Node):

--- a/tests/builder/test_connection.py
+++ b/tests/builder/test_connection.py
@@ -1,5 +1,6 @@
 import mock
 import nengo
+import numpy as np
 
 from nengo_spinnaker.builder.builder import Model
 from nengo_spinnaker.builder.model import InputPort, OutputPort
@@ -7,6 +8,9 @@ from nengo_spinnaker.builder.connection import (
     generic_source_getter,
     generic_sink_getter,
     build_generic_reception_params,
+    EnsembleTransmissionParameters,
+    PassthroughNodeTransmissionParameters,
+    NodeTransmissionParameters
 )
 
 
@@ -66,3 +70,57 @@ def test_build_standard_reception_params():
     # Build the transmission parameters
     params = build_generic_reception_params(None, a_b)
     assert params.filter is a_b.synapse
+
+
+class TestEnsembleTransmissionParameters(object):
+    def test_eq_ne(self):
+        """Create a series of EnsembleTransmissionParameters and ensure that
+        they only report equal when they are.
+        """
+        class MyETP(EnsembleTransmissionParameters):
+            pass
+
+        tp1 = EnsembleTransmissionParameters(np.ones((3, 3)), np.eye(3))
+        tp2 = EnsembleTransmissionParameters(np.ones((1, 1)), np.eye(1))
+        tp3 = EnsembleTransmissionParameters(np.eye(3), np.eye(3))
+        tp4 = MyETP(np.ones((3, 3)), np.eye(3))
+
+        assert tp1 != tp2
+        assert tp1 != tp3
+        assert tp1 != tp4
+
+        tp5 = EnsembleTransmissionParameters(np.ones((3, 3)), np.eye(3))
+        assert tp1 == tp5
+
+        tp6 = EnsembleTransmissionParameters(np.ones((3, 1)), np.ones((3, 1)))
+        assert tp1 == tp6
+
+
+class TestNodeTransmissionParameters(object):
+    def test_eq_ne(self):
+        class MyNTP(NodeTransmissionParameters):
+            pass
+
+        # NodeTransmissionParameters are only equivalent if they are of the
+        # same type, they share the same pre_slice and transform.
+        pars = [
+            (NodeTransmissionParameters, (slice(0, 5), None, np.ones((5, 5)))),
+            (NodeTransmissionParameters, (slice(None), None, np.ones((5, 5)))),
+            (NodeTransmissionParameters, (slice(0, 5), None, np.eye(5))),
+            (NodeTransmissionParameters, (slice(0, 5), None, np.ones((1, 1)))),
+            (NodeTransmissionParameters,
+             (slice(0, 5), lambda x: x, np.ones((5, 5)))),
+            (MyNTP, (slice(0, 5), None, np.ones((5, 5)))),
+        ]
+        ntps = [cls(*args) for cls, args in pars]
+
+        # Check the inequivalence works
+        for a in ntps:
+            for b in ntps:
+                if a is not b:
+                    assert a != b
+
+        # Check that equivalence works
+        for a, b in zip(ntps, [cls(*args) for cls, args in pars]):
+            assert a is not b
+            assert a == b

--- a/tests/builder/test_ensemble.py
+++ b/tests/builder/test_ensemble.py
@@ -287,28 +287,6 @@ class TestNeuronSinks(object):
         assert sink.target.port is ensemble.EnsembleInputPort.neurons
 
 
-class TestEnsembleTransmissionParameters(object):
-    def test_eq_ne(self):
-        """Create a series of EnsembleTransmissionParameters and ensure that
-        they only report equal when they are.
-        """
-        class MyETP(ensemble.EnsembleTransmissionParameters):
-            pass
-
-        tp1 = ensemble.EnsembleTransmissionParameters(np.ones((3, 3)))
-        tp2 = ensemble.EnsembleTransmissionParameters(np.ones((1, 1)))
-        tp3 = ensemble.EnsembleTransmissionParameters(np.eye(3))
-        tp4 = MyETP(np.ones((3, 3)))
-
-        assert tp1 != tp2
-        assert tp1 != tp3
-        assert tp1 != tp4
-
-        tp5 = ensemble.EnsembleTransmissionParameters(np.ones((3, 3)))
-
-        assert tp1 == tp5
-
-
 class TestBuildFromEnsembleConnection(object):
     """Test the construction of parameters that describe connections from
     Ensembles.

--- a/tests/builder/test_node.py
+++ b/tests/builder/test_node.py
@@ -8,8 +8,8 @@ from nengo_spinnaker import add_spinnaker_params
 from nengo_spinnaker.builder import Model
 from nengo_spinnaker.builder.model import OutputPort, InputPort
 from nengo_spinnaker.builder.node import (
-    NodeIOController, InputNode, OutputNode, NodeTransmissionParameters,
-    PassthroughNodeTransmissionParameters, build_node_transmission_parameters
+    NodeIOController, InputNode, OutputNode,
+    build_node_transmission_parameters
 )
 from nengo_spinnaker.operators import ValueSink
 
@@ -582,36 +582,6 @@ class TestBuildNodeTransmissionParameters(object):
         # Build the transmission parameters
         params = build_node_transmission_parameters(model, a_b)
         assert params.transform.shape == (1, 5)
-
-
-class TestNodeTransmissionParameters(object):
-    def test_eq_ne(self):
-        class MyNTP(NodeTransmissionParameters):
-            pass
-
-        # NodeTransmissionParameters are only equivalent if they are of the
-        # same type, they share the same pre_slice and transform.
-        pars = [
-            (NodeTransmissionParameters, (slice(0, 5), None, np.ones((5, 5)))),
-            (NodeTransmissionParameters, (slice(None), None, np.ones((5, 5)))),
-            (NodeTransmissionParameters, (slice(0, 5), None, np.eye(5))),
-            (NodeTransmissionParameters, (slice(0, 5), None, np.ones((1, 1)))),
-            (NodeTransmissionParameters,
-             (slice(0, 5), lambda x: x, np.ones((5, 5)))),
-            (MyNTP, (slice(0, 5), None, np.ones((5, 5)))),
-        ]
-        ntps = [cls(*args) for cls, args in pars]
-
-        # Check the inequivalence works
-        for a in ntps:
-            for b in ntps:
-                if a is not b:
-                    assert a != b
-
-        # Check that equivalence works
-        for a, b in zip(ntps, [cls(*args) for cls, args in pars]):
-            assert a is not b
-            assert a == b
 
 
 class TestInputNode(object):


### PR DESCRIPTION
- Moves all `TransmissionParameter` types into `connections` to avoid some circular imports.
- Splits up `EnsembleTransmissionParameters` so that transforms and the original decoders are remembered.

Note: I've not tested this against a booted board.

@neworderofjamie, would you mind glancing at this? It's a change that's at the base of a couple of things I'm working on but is really a separate thing.  It shouldn't require too much knowledge of `nengo_spinnaker`'s Python.
