### PR TITLE
Fix treating processes as constants

### DIFF
--- a/nengo_spinnaker/builder/node.py
+++ b/nengo_spinnaker/builder/node.py
@@ -1,4 +1,5 @@
 import nengo
+from nengo.processes import Process
 from nengo.utils.builder import full_transform
 import numpy as np
 import threading
@@ -112,11 +113,11 @@ class NodeIOController(object):
             # it.  Determine the period by looking in the config, if the output
             # is a constant then the period is dt (i.e., it repeats every
             # timestep).
-            if not callable(node.output):
-                period = model.dt
-            else:
+            if callable(node.output) or isinstance(node.output, Process):
                 period = getconfig(model.config, node,
                                    "function_of_time_period")
+            else:
+                period = model.dt
 
             vs = ValueSource(node.output, node.size_out, period)
             self._f_of_t_nodes[node] = vs

--- a/regression-tests/test_white_signal.py
+++ b/regression-tests/test_white_signal.py
@@ -11,34 +11,21 @@ from nengo.processes import WhiteSignal
 def test_white_signal():
     model = nengo.Network()
     with model:
-        # Create communication channel
-        pre = nengo.Ensemble(60, dimensions=2)
-        post = nengo.Ensemble(60, dimensions=2)
-        nengo.Connection(pre, post)
-
         inp = nengo.Node(WhiteSignal(60, high=5), size_out=2)
-        nengo.Connection(inp, pre)
-
-        # Probe signal and ensemble at end of channel
-        inp_p = nengo.Probe(pre, synapse=0.01)
-        post_p = nengo.Probe(post, synapse=0.01)
+        inp_p = nengo.Probe(inp)
 
     nengo_spinnaker.add_spinnaker_params(model.config)
     model.config[inp].function_of_time = True
 
     sim = nengo_spinnaker.Simulator(model)
     with sim:
-        sim.run(2.0)
+        sim.run(0.2)
 
     # Read data
     in_data = sim.data[inp_p]
-    post_data = sim.data[post_p]
 
-    # Calculate RMSD
-    error = np.power(in_data - post_data, 2.0)
-
-    # Assert it's less than arbitrary limit
-    assert math.sqrt(np.mean(error)) < 0.1
+    # Check that the input value actually changes
+    assert np.any(in_data[5] != in_data[6:])
 
 
 if __name__=="__main__":

--- a/tests/builder/test_node.py
+++ b/tests/builder/test_node.py
@@ -119,6 +119,27 @@ class TestNodeIOController(object):
 
         assert model.extra_operators == list()
 
+    def test_build_node_process_is_not_constant(self):
+        """Test that building a Node with a process is not treated the same as
+        building a constant valued Node.
+        """
+        with nengo.Network() as net:
+            a = nengo.Node(nengo.processes.Process())
+
+        # Create the model
+        model = Model()
+        model.config = net.config
+
+        # Build the Node
+        nioc = NodeIOController()
+        nioc.build_node(model, a)
+
+        # Assert that this added a new operator to the model
+        assert model.object_operators[a].function is a.output
+        assert model.object_operators[a].period is None
+
+        assert model.extra_operators == list()
+
     def test_build_node_probe(self):
         """Test that building a Probe of a Node results in adding a new object
         to the model and tries to build a new connection from the Node to the


### PR DESCRIPTION
Nodes with processes as their output were accidentally being treated as
if they were constants.  This fixes the related tests and the bug.

Fixes #4 (as reopened by @pabogdan)
