### PR TITLE
Revert "`calloc_sdram` for clearing and allocating SDRAM"

### DIFF
--- a/nengo_spinnaker/utils/machine_control.py
+++ b/nengo_spinnaker/utils/machine_control.py
@@ -43,19 +43,3 @@ def test_and_boot(controller, hostname, machine_width, machine_height):
     logger.info(
         "Board is booted with {} v{:.2f}".format(sver.version_string,
                                                  sver.version))
-
-
-def calloc_sdram(controller, size, **kwargs):
-    """Allocate and clear a region of SDRAM.
-
-    Returns
-    -------
-    int
-        Address of the cleared and allocated space in SDRAM.
-    """
-    # Allocate the region in SDRAM, store the start address and clear the
-    # memory.
-    mem = controller.sdram_alloc_as_filelike(size, **kwargs)
-    addr = mem.address
-    mem.write(b'\x00' * size)
-    return addr

--- a/tests/utils/test_machine_control.py
+++ b/tests/utils/test_machine_control.py
@@ -7,24 +7,6 @@ from rig.machine_control.scp_connection import TimeoutError
 from nengo_spinnaker.utils import machine_control
 
 
-@pytest.mark.parametrize("n_bytes", [100, 123])
-def test_calloc_sdram(n_bytes):
-    """Test allocating and zeroing a region of SDRAM."""
-    # Create a mock machine controller
-    cn = mock.Mock()
-    mem = cn.sdram_alloc_as_filelike.return_value = mock.Mock()
-    mem.address = 0x67800000
-
-    # Check that calling calloc_sdram() calls the controller correctly
-    addr = machine_control.calloc_sdram(cn, n_bytes)
-
-    # Assert that the returned address is correct
-    assert addr == mem.address
-
-    # Check that sufficient zeroes were written
-    mem.write.assert_called_once_with(b'\x00' * n_bytes)
-
-
 class TestTestAndBoot(object):
     def test_board_is_checked(self):
         """Test that we're happy if the board responds to an sver."""


### PR DESCRIPTION
Reverts project-rig/nengo_spinnaker#83 as a result of project-rig/rig#191
