### PR TITLE
Use new Rig v0.11.0 API functions.

### DIFF
--- a/nengo_spinnaker/node_io/ethernet.py
+++ b/nengo_spinnaker/node_io/ethernet.py
@@ -2,7 +2,7 @@ import collections
 import numpy as np
 from rig.machine_control.consts import SCP_PORT
 from rig.machine_control.packets import SCPPacket
-from rig.machine import Cores
+from rig.place_and_route import Cores
 from six import iteritems
 import socket
 import threading

--- a/nengo_spinnaker/operators/filter.py
+++ b/nengo_spinnaker/operators/filter.py
@@ -1,5 +1,5 @@
 import numpy as np
-from rig.machine import Cores, SDRAM
+from rig.place_and_route import Cores, SDRAM
 import struct
 
 from nengo_spinnaker.builder.builder import netlistspec

--- a/nengo_spinnaker/operators/lif.py
+++ b/nengo_spinnaker/operators/lif.py
@@ -10,7 +10,7 @@ from bitarray import bitarray
 import collections
 from nengo.base import ObjView
 import numpy as np
-from rig.machine import Cores, SDRAM
+from rig.place_and_route import Cores, SDRAM
 import struct
 
 from nengo_spinnaker.builder.builder import netlistspec

--- a/nengo_spinnaker/operators/sdp_receiver.py
+++ b/nengo_spinnaker/operators/sdp_receiver.py
@@ -1,4 +1,4 @@
-from rig.machine import Cores, SDRAM
+from rig.place_and_route import Cores, SDRAM
 import six
 import struct
 

--- a/nengo_spinnaker/operators/sdp_transmitter.py
+++ b/nengo_spinnaker/operators/sdp_transmitter.py
@@ -1,4 +1,4 @@
-from rig.machine import Cores, SDRAM
+from rig.place_and_route import Cores, SDRAM
 import struct
 
 from nengo_spinnaker.builder.builder import netlistspec

--- a/nengo_spinnaker/operators/value_sink.py
+++ b/nengo_spinnaker/operators/value_sink.py
@@ -1,5 +1,5 @@
 import numpy as np
-from rig.machine import Cores, SDRAM
+from rig.place_and_route import Cores, SDRAM
 import struct
 
 from nengo_spinnaker.builder.builder import netlistspec

--- a/nengo_spinnaker/operators/value_source.py
+++ b/nengo_spinnaker/operators/value_source.py
@@ -1,7 +1,7 @@
 import collections
 import math
 import numpy as np
-from rig.machine import Cores, SDRAM
+from rig.place_and_route import Cores, SDRAM
 import struct
 
 from nengo.processes import Process

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -5,7 +5,7 @@ from nengo.cache import get_default_decoder_cache
 import numpy as np
 from rig.machine_control import MachineController
 from rig.machine_control.consts import AppState
-from rig.machine import Cores
+from rig.place_and_route import Cores
 import rig.place_and_route
 import six
 import time
@@ -120,14 +120,14 @@ class Simulator(object):
         start = time.time()
         self.netlist = self.model.make_netlist(self.max_steps or 0)
 
-        # Get a machine object to place & route against
+        # Get a system-info object to place & route against
         logger.info("Getting SpiNNaker machine specification")
-        machine = self.controller.get_machine()
+        system_info = self.controller.get_system_info()
 
         # Place & Route
         logger.info("Placing and routing")
         self.netlist.place_and_route(
-            machine,
+            system_info,
             place=getconfig(network.config, Simulator,
                             'placer', rig.place_and_route.place),
             place_kwargs=getconfig(network.config, Simulator,
@@ -166,7 +166,7 @@ class Simulator(object):
         for x in range(machine_width):
             for y in range(machine_height):
                 with self.controller(x=x, y=y):
-                    if (x, y) in machine:
+                    if (x, y) in system_info:
                         data = self.controller.read(0xf1000000, 4)
                         self.controller.write(0xf1000000, data[:-1] + b'\x10')
 

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     keywords="spinnaker nengo neural cognitive simulation",
 
     # Requirements
-    install_requires=["nengo>=2.0.0, <3.0.0", "rig>=0.10.0, <1.0.0",
+    install_requires=["nengo>=2.0.0, <3.0.0", "rig>=0.11.0, <1.0.0",
                       "bitarray>=0.8.1, <1.0.0"],
     zip_safe=False,  # Partly for performance reasons
 

--- a/tests/builder/test_builder.py
+++ b/tests/builder/test_builder.py
@@ -527,7 +527,7 @@ class TestMakeNetlist(object):
         assert set(netlist.vertices) == set([vertex_a, vertex_b])
         assert netlist.keyspaces is model.keyspaces
         assert netlist.groups == list()
-        assert set(netlist.constraints[:-1]) == set([constraint_a, constraint_b])
+        assert set(netlist.constraints) == set([constraint_a, constraint_b])
         assert set(netlist.load_functions) == set([load_fn_a, load_fn_b])
         assert netlist.before_simulation_functions == [pre_fn_a]
         assert netlist.after_simulation_functions == [post_fn_a]
@@ -569,7 +569,7 @@ class TestMakeNetlist(object):
         assert set(netlist.vertices) == set([vertex_a, vertex_b])
         assert netlist.keyspaces is model.keyspaces
         assert netlist.groups == list()
-        assert len(netlist.constraints) == 1
+        assert len(netlist.constraints) == 0
         assert set(netlist.load_functions) == set([load_fn_a, load_fn_b])
         assert netlist.before_simulation_functions == [pre_fn_a]
         assert netlist.after_simulation_functions == [post_fn_a]
@@ -644,7 +644,7 @@ class TestMakeNetlist(object):
         # Check that the groups are correct
         assert netlist.groups == [set([vertex_b0, vertex_b1])]
 
-        assert len(netlist.constraints) == 1
+        assert len(netlist.constraints) == 0
 
     def test_multiple_source_vertices(self):
         """Test that each of the vertices associated with a source is correctly
@@ -707,7 +707,7 @@ class TestMakeNetlist(object):
             assert net.sinks == [vertex_b]
 
         assert netlist.groups == [set([vertex_a0, vertex_a1, vertex_a2])]
-        assert len(netlist.constraints) == 1
+        assert len(netlist.constraints) == 0
 
         # Check that `transmit_signal` was called correctly
         sig, tp = vertex_a2.args

--- a/tests/netlist/test_netlist_netlist.py
+++ b/tests/netlist/test_netlist_netlist.py
@@ -1,8 +1,7 @@
 import mock
 import pytest
 from rig.bitfield import BitField
-from rig import machine
-from rig.machine import Cores, SDRAM
+from rig.place_and_route import Cores, SDRAM
 from rig.place_and_route.constraints import (ReserveResourceConstraint,
                                              LocationConstraint)
 

--- a/tests/netlist/test_netlist_utils.py
+++ b/tests/netlist/test_netlist_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from rig.machine import Cores
+from rig.place_and_route import Cores
 
 from nengo_spinnaker.utils.keyspaces import KeyspaceContainer
 from nengo_spinnaker.netlist import NMNet, Vertex, utils

--- a/tests/operators/test_sdp_receiver.py
+++ b/tests/operators/test_sdp_receiver.py
@@ -1,7 +1,7 @@
 import mock
 import numpy as np
 import pytest
-from rig.machine import Cores, SDRAM
+from rig.place_and_route import Cores, SDRAM
 import six
 import struct
 import tempfile


### PR DESCRIPTION
This commit migrates to the new place-and-route wrapper introduced in Rig
v0.11.0 which automatically reserves non-idle cores allowing easier use of
profiling tools.

Unfortunately I don't know how to run the live-hardware tests (and don't have a board to hand anyway) so these changes merely pass the basic test suite and seem to make sense to me. Sorry!
