### PR TITLE
Improve passthrough Node removal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
 
     # Requirements
     install_requires=["nengo>=2.0.0, <3.0.0", "rig>=1.0.0, <2.0.0",
-                      "bitarray>=0.8.1, <1.0.0"],
+                      "bitarray>=0.8.1, <1.0.0", "toposort >= 1.4"],
     zip_safe=False,  # Partly for performance reasons
 
     # Scripts


### PR DESCRIPTION
Two commits:
- The first updates the heuristic for passthrough Node removal to account for column-wise decomposition of passthrough Nodes (as per #107)
- The second adds some determinism to passthrough Node removal by performing a topological sort of (sub)networks containing PTNs and removing the PTNs in decreasing order of depth.

@tcstewar, do you have any thoughts on this? @neworderofjamie?

Certainly there's room for improving either heuristic, but this seems like a good start and has made some improvements in network performance in the tests of large-scale cconvs that I've been doing.
