### PR TITLE
Use spalloc to get a SpiNNaker machine

### DIFF
--- a/nengo_spinnaker/node_io/ethernet.py
+++ b/nengo_spinnaker/node_io/ethernet.py
@@ -85,7 +85,7 @@ class Ethernet(NodeIOController):
 
         # Set up the IP tag (will need to do this for each ethernet connected
         # chip that we expect to use).
-        self.in_socket.bind(('', 50007))
+        self.in_socket.bind(('', 0))
         with controller(x=0, y=0):
             controller.iptag_set(1, *self.in_socket.getsockname())
 

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -166,7 +166,7 @@ class Simulator(object):
             # spalloc recommends a slight delay before attempting to boot the
             # machine, later versions of spalloc server may relax this
             # requirement.
-            time.sleep(1)
+            time.sleep(5.0)
 
             # Store the hostname
             hostname = self.job.hostname

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -69,13 +69,6 @@ class Simulator(object):
         # Add this simulator to the set of open simulators
         Simulator._add_simulator(self)
 
-        # Create a controller for the machine and boot if necessary
-        if hostname is None:
-            hostname = rc.get("spinnaker_machine", "hostname")
-
-        self.controller = MachineController(hostname)
-        self.controller.boot()
-
         # Create the IO controller
         io_cls = getconfig(network.config, Simulator, "node_io", Ethernet)
         io_kwargs = getconfig(network.config, Simulator, "node_io_kwargs",
@@ -130,6 +123,13 @@ class Simulator(object):
         logger.info("Building netlist")
         start = time.time()
         self.netlist = self.model.make_netlist(self.max_steps or 0)
+
+        # Create a controller for the machine and boot if necessary
+        if hostname is None:
+            hostname = rc.get("spinnaker_machine", "hostname")
+
+        self.controller = MachineController(hostname)
+        self.controller.boot()
 
         # Get a system-info object to place & route against
         logger.info("Getting SpiNNaker machine specification")

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -50,7 +50,8 @@ class Simulator(object):
     def _remove_simulator(cls, simulator):
         cls._open_simulators.remove(simulator)
 
-    def __init__(self, network, dt=0.001, period=10.0, timescale=1.0):
+    def __init__(self, network, dt=0.001, period=10.0, timescale=1.0,
+                 hostname=None):
         """Create a new Simulator with the given network.
 
         Parameters
@@ -61,12 +62,16 @@ class Simulator(object):
         timescale : float
             Scaling factor to apply to the simulation, e.g., a value of `0.5`
             will cause the simulation to run at half real-time.
+        hostname : string or None
+            Hostname of the SpiNNaker machine to use; if None then the machine
+            specified in the config file will be used.
         """
         # Add this simulator to the set of open simulators
         Simulator._add_simulator(self)
 
         # Create a controller for the machine and boot if necessary
-        hostname = rc.get("spinnaker_machine", "hostname")
+        if hostname is None:
+            hostname = rc.get("spinnaker_machine", "hostname")
 
         self.controller = MachineController(hostname)
         self.controller.boot()

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -181,7 +181,7 @@ class Simulator(object):
             # Store the hostname
             hostname = self.job.hostname
             logger.info("Using %d board(s) of \"%s\" (%s)",
-                        n_boards, self.job.machine_name, hostname)
+                        len(self.job.boards), self.job.machine_name, hostname)
 
         self.controller = MachineController(hostname)
         self.controller.boot()

--- a/setup.py
+++ b/setup.py
@@ -99,5 +99,10 @@ setup(
         "console_scripts": [
             "nengo_spinnaker_setup = nengo_spinnaker.scripts.nengo_spinnaker_setup:main",
         ],
-    }
+    },
+
+    # Extras
+    extras_require={
+        "spalloc": ["spalloc >= 0.2.2"],  # For machine allocation
+    },
 )


### PR DESCRIPTION
- Use [spalloc](https://github.com/project-rig/spalloc) to get automatically allocated SpiNNaker boards
- Allow the Simulator be called with the hostname of the SpiNNaker board to use
- Use the OS to get a port for incoming packets from SpiNNaker

@pabogdan - I believe that the latter two points are things you also did at some point?
