### PR TITLE
Safely remove passthrough Nodes with no input

### DIFF
--- a/nengo_spinnaker/utils/model.py
+++ b/nengo_spinnaker/utils/model.py
@@ -168,7 +168,7 @@ def remove_operator_from_connection_map(conn_map, target, force=True):
             conn_map.add_connection(**kwargs)
 
     # Determine whether the changes made should be discarded.
-    new_max_packets = max(itervalues(new_rx))
+    new_max_packets = 0 if not new_rx else max(itervalues(new_rx))
     discard_changes = new_max_packets > old_max_packets
 
     # If not forced and we caused a worsening in network usage then copy the


### PR DESCRIPTION
Fixes a bug which resulted from attempting to remove a passthrough Node
with no incoming connections.

For example, the network:

``` python
with nengo.Network() as network:
    nengo.networks.EnsembleArray(800, 32, 16)
```

Will not run on SpiNNaker as remove the input node to the ensemble array will fail.
