### PR TITLE
Reduce ensemble transmission pars memory usage

### DIFF
--- a/nengo_spinnaker/builder/connection.py
+++ b/nengo_spinnaker/builder/connection.py
@@ -29,60 +29,10 @@ def build_generic_reception_params(model, conn):
                                conn.learning_rule)
 
 
-class EnsembleTransmissionParameters(object):
-    """Transmission parameters for a connection originating at an Ensemble.
-
-    Attributes
-    ----------
-    decoders : array
-        Decoders to use for the connection.
-    """
-    def __init__(self, decoders, transform, learning_rule):
-        # Copy the decoders
-        self.untransformed_decoders = np.array(decoders)
-        self.transform = np.array(transform)
-
-        # Cache learning rule
-        self.learning_rule = learning_rule
-
-        # Compute and store the transformed decoders
-        self.decoders = np.dot(transform, decoders.T)
-
-        # Make the arrays read-only
-        self.untransformed_decoders.flags['WRITEABLE'] = False
-        self.transform.flags['WRITEABLE'] = False
-        self.decoders.flags['WRITEABLE'] = False
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __eq__(self, other):
-        # Equal iff. the objects are of the same type
-        if type(self) is not type(other):
-            return False
-
-        # Equal iff. neither connection has a learning rule
-        if self.learning_rule is not None or other.learning_rule is not None:
-            return False
-
-        # Equal iff. the decoders are the same shape
-        if self.decoders.shape != other.decoders.shape:
-            return False
-
-        # Equal iff. the decoder values are the same
-        if np.any(self.decoders != other.decoders):
-            return False
-
-        return True
-
-
-class PassthroughNodeTransmissionParameters(object):
-    """Parameters describing connections which originate from pass through
-    Nodes.
-    """
+class TransmissionParameters(object):
+    """Parameters describing generic connections."""
     def __init__(self, transform):
-        # Store the parameters, copying the transform
-        self.transform = np.array(transform)
+        self.transform = transform
 
     def __ne__(self, other):
         return not (self == other)
@@ -98,6 +48,37 @@ class PassthroughNodeTransmissionParameters(object):
             return False
 
         return True
+
+
+class EnsembleTransmissionParameters(TransmissionParameters):
+    """Transmission parameters for a connection originating at an Ensemble.
+
+    Attributes
+    ----------
+    transform : array
+        Decoders to use for the connection (n_dims x n_neurons)
+    """
+    def __init__(self, transform, learning_rule):
+        super(EnsembleTransmissionParameters, self).__init__(transform)
+
+        # Cache learning rule
+        self.learning_rule = learning_rule
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __eq__(self, other):
+        # Equal iff. neither connection has a learning rule
+        if self.learning_rule is not None or other.learning_rule is not None:
+            return False
+
+        return super(EnsembleTransmissionParameters, self).__eq__(other)
+
+
+class PassthroughNodeTransmissionParameters(TransmissionParameters):
+    """Parameters describing connections which originate from pass through
+    Nodes.
+    """
 
 
 class NodeTransmissionParameters(PassthroughNodeTransmissionParameters):

--- a/nengo_spinnaker/builder/ensemble.py
+++ b/nengo_spinnaker/builder/ensemble.py
@@ -259,8 +259,9 @@ def build_from_ensemble_connection(model, conn):
             np.all(transform[0, :] == transform[1:, :])):
         transform = np.array([transform[0]])
 
-    return EnsembleTransmissionParameters(decoders, transform,
-                                          conn.learning_rule)
+    transform = np.dot(transform, decoders.T)
+
+    return EnsembleTransmissionParameters(transform, conn.learning_rule)
 
 
 @Model.transmission_parameter_builders.register(nengo.ensemble.Neurons)

--- a/nengo_spinnaker/operators/filter.py
+++ b/nengo_spinnaker/operators/filter.py
@@ -304,13 +304,9 @@ class FilterCore(Vertex):
 
     def accepts_signal(self, signal_params, transmission_params):
         """Choose whether to receive this signal or not."""
-        if isinstance(transmission_params, EnsembleTransmissionParameters):
-            # If the connection is from an ensemble only return true if the
-            # decoders contain non-zero values in the input dimensions we care
-            # about.
-            return np.any(transmission_params.decoders[self.column_slice, :])
-        elif isinstance(transmission_params,
-                        PassthroughNodeTransmissionParameters):
+        if isinstance(transmission_params,
+                      (PassthroughNodeTransmissionParameters,
+                       EnsembleTransmissionParameters)):
             # If the connection is from a Node of some variety then only return
             # true if the transform contains non-zero values in the rows which
             # relate to the subspace we receive input in.

--- a/nengo_spinnaker/operators/lif.py
+++ b/nengo_spinnaker/operators/lif.py
@@ -1142,7 +1142,7 @@ def get_decoders_and_keys(signals_connections, minimise=False):
     # For each signal with a single connection we save the decoder and generate
     # appropriate keys
     for signal, transmission_params in signals_connections:
-        decoder = transmission_params.decoders
+        decoder = transmission_params.transform
 
         if not minimise:
             keep = np.array([True for _ in range(decoder.shape[0])])

--- a/nengo_spinnaker/operators/value_sink.py
+++ b/nengo_spinnaker/operators/value_sink.py
@@ -132,13 +132,9 @@ class ValueSinkVertex(Vertex):
 
     def accepts_signal(self, signal_params, transmission_params):
         """Choose whether to receive this signal or not."""
-        if isinstance(transmission_params, EnsembleTransmissionParameters):
-            # If the connection is from an ensemble only return true if the
-            # decoders contain non-zero values in the input dimensions we care
-            # about.
-            return np.any(transmission_params.decoders[self.input_slice, :])
-        elif isinstance(transmission_params,
-                        PassthroughNodeTransmissionParameters):
+        if isinstance(transmission_params,
+                      (PassthroughNodeTransmissionParameters,
+                       EnsembleTransmissionParameters)):
             # If the connection is from a Node of some variety then only return
             # true if the transform contains non-zero values in the rows which
             # relate to the subspace we receive input in.

--- a/nengo_spinnaker/utils/model.py
+++ b/nengo_spinnaker/utils/model.py
@@ -374,7 +374,6 @@ def _combine_transmission_params(in_transmission_parameters,
     if isinstance(in_transmission_parameters,
                   EnsembleTransmissionParameters):
         transmission_params = EnsembleTransmissionParameters(
-            in_transmission_parameters.untransformed_decoders,
             new_transform, in_transmission_parameters.learning_rule
         )
     elif isinstance(in_transmission_parameters,

--- a/tests/builder/test_connection.py
+++ b/tests/builder/test_connection.py
@@ -80,24 +80,21 @@ class TestEnsembleTransmissionParameters(object):
         class MyETP(EnsembleTransmissionParameters):
             pass
 
-        tp1 = EnsembleTransmissionParameters(np.ones((3, 3)), np.eye(3), None)
-        tp2 = EnsembleTransmissionParameters(np.ones((1, 1)), np.eye(1), None)
-        tp3 = EnsembleTransmissionParameters(np.eye(3), np.eye(3), None)
-        tp4 = MyETP(np.ones((3, 3)), np.eye(3), None)
+        tp1 = EnsembleTransmissionParameters(np.ones((3, 3)), None)
+        tp2 = EnsembleTransmissionParameters(np.ones((1, 1)), None)
+        tp3 = EnsembleTransmissionParameters(np.eye(3), None)
+        tp4 = MyETP(np.ones((3, 3)), None)
 
         assert tp1 != tp2
         assert tp1 != tp3
         assert tp1 != tp4
 
-        tp5 = EnsembleTransmissionParameters(np.ones((3, 3)), np.eye(3), None)
+        tp5 = EnsembleTransmissionParameters(np.ones((3, 3)), None)
         assert tp1 == tp5
 
-        tp6 = EnsembleTransmissionParameters(np.ones((3, 1)), np.ones((3, 1)), None)
-        assert tp1 == tp6
-
         learning_rule = mock.Mock()
-        tp7 = EnsembleTransmissionParameters(np.ones((3, 1)), np.ones((3, 1)), learning_rule)
-        tp8 = EnsembleTransmissionParameters(np.ones((3, 1)), np.ones((3, 1)), learning_rule)
+        tp7 = EnsembleTransmissionParameters(np.ones((3, 1)), learning_rule)
+        tp8 = EnsembleTransmissionParameters(np.ones((3, 1)), learning_rule)
         assert tp7 != tp8
 
 

--- a/tests/builder/test_ensemble.py
+++ b/tests/builder/test_ensemble.py
@@ -410,8 +410,8 @@ class TestBuildFromEnsembleConnection(object):
 
         # Now build the connection and check that the params seem sensible
         tparams = ensemble.build_from_ensemble_connection(model, a_b)
-        assert tparams.decoders.shape == (2, 200)
-        assert np.all(tparams.decoders[1, :] == 0.0)
+        assert tparams.transform.shape == (2, 200)
+        assert np.all(tparams.transform[1, :] == 0.0)
 
         # Check that the params stored in the model are correct
         params = model.params[a_b]
@@ -440,7 +440,7 @@ class TestBuildFromEnsembleConnection(object):
 
         # Now build the connection and check that the params seem sensible
         tparams = ensemble.build_from_ensemble_connection(model, a_b)
-        assert tparams.decoders.shape == (1, 200)
+        assert tparams.transform.shape == (1, 200)
 
         # Check that the params stored in the model are correct
         params = model.params[a_b]


### PR DESCRIPTION
Instead of storing 3(!?) matrices representing the decoders and transforms applied to a connection originating at an ensemble only store 1. This should significantly decrease memory usage, and may lead to a speed up when removing passthrough nodes from a network.
