### PR TITLE
Improve build time

### DIFF
--- a/nengo_spinnaker/builder/connection.py
+++ b/nengo_spinnaker/builder/connection.py
@@ -4,6 +4,11 @@ import numpy as np
 from .builder import Model, ObjectPort, spec
 from .model import ReceptionParameters, InputPort, OutputPort
 
+try:
+    from xxhash import xxh64 as fast_hash
+except ImportError:
+    from hashlib import md5 as fast_hash
+
 
 @Model.source_getters.register(nengo.base.NengoObject)
 def generic_source_getter(model, conn):
@@ -50,7 +55,7 @@ class TransmissionParameters(object):
         return True
 
     def _get_hashables(self):
-        return (type(self), self.transform.data)
+        return (type(self), fast_hash(self.transform).hexdigest())
 
     def __hash__(self):
         return hash(self._get_hashables())

--- a/nengo_spinnaker/builder/connection.py
+++ b/nengo_spinnaker/builder/connection.py
@@ -54,11 +54,12 @@ class TransmissionParameters(object):
 
         return True
 
-    def _get_hashables(self):
+    @property
+    def _hashables(self):
         return (type(self), fast_hash(self.transform).hexdigest())
 
     def __hash__(self):
-        return hash(self._get_hashables())
+        return hash(self._hashables)
 
 
 class EnsembleTransmissionParameters(TransmissionParameters):
@@ -87,7 +88,7 @@ class EnsembleTransmissionParameters(TransmissionParameters):
 
     def __hash__(self):
         return hash(
-            super(EnsembleTransmissionParameters, self)._get_hashables() +
+            super(EnsembleTransmissionParameters, self)._hashables +
             (self.learning_rule, )
         )
 
@@ -125,6 +126,7 @@ class NodeTransmissionParameters(PassthroughNodeTransmissionParameters):
 
         return True
 
-    def _get_hashables(self):
-        return (super(NodeTransmissionParameters, self)._get_hashables() +
+    @property
+    def _hashables(self):
+        return (super(NodeTransmissionParameters, self)._hashables +
                 (self.function, ))

--- a/nengo_spinnaker/utils/model.py
+++ b/nengo_spinnaker/utils/model.py
@@ -207,7 +207,11 @@ def remove_operator_from_connection_map(conn_map, target, force=True,
 
     # Create a new empty connection map dictionary and update the connection
     # map to use the new dictionary
-    conns = collections.defaultdict(lambda: collections.defaultdict(list))
+    conns = collections.defaultdict(
+        lambda: collections.defaultdict(
+            lambda: collections.defaultdict(list)
+        )
+    )
     conn_map._connections = conns
 
     # Copy across all connections from the old connection map; every time we
@@ -274,18 +278,13 @@ def _get_port_kwargs(ports_and_signals):
     """
     # Iterate through the dictionary
     for source_port, signals_and_sinks in iteritems(ports_and_signals):
-        for signal_and_sink in signals_and_sinks:
-            for (sink_object, sink_port,
-                 reception_parameters) in signal_and_sink.sinks:
-                # Break out the signal and transmission parameters
-                signal_parameters, transmission_parameters = \
-                    signal_and_sink.parameters
-
+        for (sig_pars, trans_pars), sinks in iteritems(signals_and_sinks):
+            for (sink_object, sink_port, reception_parameters) in sinks:
                 # Yield the keyword arguments for this connection
                 yield {
                     "source_port": source_port,
-                    "signal_parameters": signal_parameters,
-                    "transmission_parameters": transmission_parameters,
+                    "signal_parameters": sig_pars,
+                    "transmission_parameters": trans_pars,
                     "sink_object": sink_object,
                     "sink_port": sink_port,
                     "reception_parameters": reception_parameters,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-git+https://github.com/nengo/nengo#egg=nengo
-git+https://github.com/project-rig/rig#egg=rig
+nengo==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -105,5 +105,6 @@ setup(
     extras_require={
         "spalloc": ["spalloc >= 0.2.2"],  # For machine allocation
         "scipy": ["scipy >= 0.11"],         # For processing of profiler output
+        "xxhash": ["xxhash"],            # Faster network build
     },
 )

--- a/tests/builder/test_connection.py
+++ b/tests/builder/test_connection.py
@@ -91,6 +91,7 @@ class TestEnsembleTransmissionParameters(object):
 
         tp5 = EnsembleTransmissionParameters(np.ones((3, 3)), None)
         assert tp1 == tp5
+        assert hash(tp1) == hash(tp5)
 
         learning_rule = mock.Mock()
         tp7 = EnsembleTransmissionParameters(np.ones((3, 1)), learning_rule)

--- a/tests/utils/test_utils_model.py
+++ b/tests/utils/test_utils_model.py
@@ -2,6 +2,7 @@ import mock
 import nengo
 import numpy as np
 import pytest
+from six import iteritems
 
 from nengo_spinnaker.utils import model as model_utils
 from nengo_spinnaker.builder import model, Model
@@ -217,7 +218,7 @@ def test_remove_operator_from_connection_map():
     assert len(from_o1) == 1
     assert len(from_o1[None]) == 1
 
-    ((signal_parameters, transmission_parameters), sinks) = from_o1[None][0]
+    ((signal_parameters, transmission_parameters), sinks) = next(iteritems(from_o1[None]))
     assert signal_parameters == model.SignalParameters(True, 3, None)
     assert transmission_parameters.transform.shape == (3, 3)
     assert np.all(transmission_parameters.transform == np.eye(3)*2)
@@ -229,7 +230,7 @@ def test_remove_operator_from_connection_map():
     assert len(from_o2) == 1
     assert len(from_o2[None]) == 3
 
-    for ((signal_parameters, transmission_parameters), sinks) in from_o2[None]:
+    for ((signal_parameters, transmission_parameters), sinks) in iteritems(from_o2[None]):
         if transmission_parameters.transform.shape == (3, 3):
             assert (signal_parameters ==
                     model.SignalParameters(False, 3, None))
@@ -415,7 +416,7 @@ def test_remove_operator_from_connection_map_unforced():
         assert len(from_a) == 1
         assert len(from_a[None]) == 1
 
-        ((signal_parameters, transmission_parameters), sinks) = from_a[None][0]
+        ((signal_parameters, transmission_parameters), sinks) = next(iteritems(from_a[None]))
         assert signal_parameters == model.SignalParameters(True, SD, None)
         assert transmission_parameters.transform.shape == (SD, 1)
         assert sinks == [(d, None, model.ReceptionParameters(None, SD, None))]
@@ -425,14 +426,13 @@ def test_remove_operator_from_connection_map_unforced():
         assert len(from_d) == 1
         assert len(from_d[None]) == 1
 
-        ((signal_parameters, transmission_parameters), sinks) = from_d[None][0]
+        ((signal_parameters, transmission_parameters), sinks) = next(iteritems(from_d[None]))
         assert signal_parameters == model.SignalParameters(True, D, None)
         assert transmission_parameters.transform.shape == (D, 1)
 
     # Check that there are many connections from E
     from_e = cm._connections[op_E]
     assert len(from_e) == 1
-    print(from_e[None][0].parameters[1].transform)
     assert len(from_e[None]) == D
 
 


### PR DESCRIPTION
Changes the way in which connections are stored so that the processing required when optimising out passthrough nodes is faster.

In addition this switches testing to test against the most recent release of Nengo (this may be changed back to master later but is up for discussion - @tcstewar).
## Details

Connections used to be stored using a list-derived structure, this is now changed to a dictionary. Since repeated hashing was found to be ludicrously slow a faster hashing package is used when installed. The changes in these commits simply change the data structure (1) and add support for this faster hashing (2). The change to the test requirements is (3).
