### PR TITLE
Improved routing key assignment with graph colouring

### DIFF
--- a/nengo_spinnaker/builder/builder.py
+++ b/nengo_spinnaker/builder/builder.py
@@ -5,7 +5,7 @@ import nengo
 from nengo.cache import NoDecoderCache
 from nengo.utils import numpy as npext
 import numpy as np
-from six import itervalues
+from six import iteritems, itervalues
 
 from . import model
 from nengo_spinnaker.netlist import NMNet, Netlist
@@ -325,6 +325,9 @@ class Model(object):
         after_simulation_functions = collections_ext.noneignoringlist()
         constraints = collections_ext.flatinsertionlist()
 
+        # Prepare to build a list of signal constraints
+        id_constraints = collections.defaultdict(set)
+
         for op in itertools.chain(itervalues(self.object_operators),
                                   self.extra_operators):
             # Skip any operators that were previously removed
@@ -347,6 +350,22 @@ class Model(object):
             if constraint is not None:
                 constraints.append(constraint)
 
+            # Get the constraints on signal identifiers
+            if hasattr(op, "get_signal_constraints"):
+                # Ask the operator what constraints exist upon the keys it can
+                # accept.
+                for u, vs in iteritems(op.get_signal_constraints()):
+                    id_constraints[u].update(vs)
+            else:
+                # Otherwise assume that all signals arriving at the operator
+                # must be uniquely identified.
+                incoming_all = itertools.chain(
+                    *itervalues(self.connection_map.get_signals_to_object(op)))
+                for (u, _), (v, _) in itertools.combinations(incoming_all, 2):
+                    if u != v:
+                        id_constraints[u].add(v)
+                        id_constraints[v].add(u)
+
         # Construct the groups set
         groups = list()
         for vxs in itervalues(operator_vertices):
@@ -357,6 +376,7 @@ class Model(object):
 
         # Construct nets from the signals
         nets = dict()
+        id_to_signal = dict()
         for signal, transmission_parameters in \
                 self.connection_map.get_signals():
             # Get the source and sink vertices
@@ -396,7 +416,15 @@ class Model(object):
                              s.accepts_signal(signal, transmission_parameters))
 
             # Create the net(s)
+            id_to_signal[id(signal._params)] = signal  # Yuck
             nets[signal] = NMNet(sources, list(sinks), signal.weight)
+
+        # Get the constraints on the signal identifiers
+        signal_id_constraints = dict()
+        for u, vs in id_constraints:
+            signal_id_constraints[id_to_signal[u]] = {
+                id_to_signal[v] for v in vs
+            }
 
         # Return a netlist
         return Netlist(
@@ -407,7 +435,8 @@ class Model(object):
             constraints=constraints,
             load_functions=load_functions,
             before_simulation_functions=before_simulation_functions,
-            after_simulation_functions=after_simulation_functions
+            after_simulation_functions=after_simulation_functions,
+            signal_id_constraints=signal_id_constraints
         )
 
 

--- a/nengo_spinnaker/builder/builder.py
+++ b/nengo_spinnaker/builder/builder.py
@@ -421,7 +421,7 @@ class Model(object):
 
         # Get the constraints on the signal identifiers
         signal_id_constraints = dict()
-        for u, vs in id_constraints:
+        for u, vs in iteritems(id_constraints):
             signal_id_constraints[id_to_signal[u]] = {
                 id_to_signal[v] for v in vs
             }

--- a/nengo_spinnaker/netlist/key_allocation.py
+++ b/nengo_spinnaker/netlist/key_allocation.py
@@ -89,10 +89,11 @@ def build_mn_net_graph(nets_routes, prior_constraints=None):
     net_graph = {net: set() for net in iterkeys(nets_routes)}
     for route_nets in itervalues(chip_route_nets):
         for xs, ys in itertools.combinations(itervalues(route_nets), 2):
-            for x, y in ((i, j) for j in ys for i in xs if i != j):
+            for x, y in itertools.product(xs, ys):
                 # Add an edge iff. it would connect two *different* vertices
-                net_graph[x].add(y)
-                net_graph[y].add(x)
+                if x != y:
+                    net_graph[x].add(y)
+                    net_graph[y].add(x)
 
     # Add any prior constraints into the net graph (doing so in such a way that
     # ensures that the prior constraints are undirected).

--- a/nengo_spinnaker/netlist/key_allocation.py
+++ b/nengo_spinnaker/netlist/key_allocation.py
@@ -24,7 +24,7 @@ def allocate_signal_keyspaces(signal_routes, signal_id_constraints, keyspaces):
 
     if (signal_ids):
         logger.info("%u signals assigned %u IDs", len(signal_ids),
-                    max(itervalues(signal_ids)))
+                    max(itervalues(signal_ids)) + 1)
 
 
 def assign_mn_net_ids(nets_routes, prior_constraints=None):

--- a/nengo_spinnaker/netlist/netlist.py
+++ b/nengo_spinnaker/netlist/netlist.py
@@ -56,7 +56,8 @@ class Netlist(object):
     """
     def __init__(self, nets, vertices, keyspaces, groups, constraints=list(),
                  load_functions=list(), before_simulation_functions=list(),
-                 after_simulation_functions=list()):
+                 after_simulation_functions=list(),
+                 signal_id_constraints=dict()):
         # Store given parameters
         self.nets = nets
         self.vertices = vertices
@@ -66,6 +67,7 @@ class Netlist(object):
         self.load_functions = list(load_functions)
         self.before_simulation_functions = list(before_simulation_functions)
         self.after_simulation_functions = list(after_simulation_functions)
+        self.signal_id_constraints = signal_id_constraints
 
         # Create containers for the attributes that are filled in by place and
         # route.
@@ -149,6 +151,7 @@ class Netlist(object):
                 signal_routes[signal].append(self.routes[net])
 
         key_allocation.allocate_signal_keyspaces(signal_routes,
+                                                 self.signal_id_constraints,
                                                  self.keyspaces)
 
         # Get a map from the nets we will route with to keyspaces

--- a/nengo_spinnaker/operators/filter.py
+++ b/nengo_spinnaker/operators/filter.py
@@ -119,6 +119,7 @@ class Filter(object):
             model.keyspaces.filter_routing_tag,
             width=self.size_in
         )
+        self._routing_region = filter_routing_region
 
         # Generate the vertices
         vertices = flatinsertionlist()
@@ -134,6 +135,18 @@ class Filter(object):
         # Return the netlist specification
         return netlistspec(vertices=vertices,
                            load_function=self.load_to_machine)
+
+    def get_signal_constraints(self):
+        """Return a set of constraints on which signal parameters may share the
+        same keyspace.
+
+        Returns
+        -------
+        {id(SignalParameters): {id(SignalParameters), ...}}
+            A (moderately unpleasant) dictionary of which signal parameters
+            cannot share a routing identifier.
+        """
+        return self._routing_region.get_signal_constraints()
 
     def load_to_machine(self, netlist, controller):
         """Load the data to the machine."""

--- a/nengo_spinnaker/operators/sdp_transmitter.py
+++ b/nengo_spinnaker/operators/sdp_transmitter.py
@@ -48,6 +48,18 @@ class SDPTransmitter(object):
         return netlistspec(self._vertex,
                            load_function=self.load_to_machine)
 
+    def get_signal_constraints(self):
+        """Return a set of constraints on which signal parameters may share the
+        same keyspace.
+
+        Returns
+        -------
+        {id(SignalParameters): {id(SignalParameters), ...}}
+            A (moderately unpleasant) dictionary of which signal parameters
+            cannot share a routing identifier.
+        """
+        return self._routing_region.get_signal_constraints()
+
     def load_to_machine(self, netlist, controller):
         """Load data to the machine."""
         # Get the memory

--- a/nengo_spinnaker/operators/value_sink.py
+++ b/nengo_spinnaker/operators/value_sink.py
@@ -57,6 +57,7 @@ class ValueSink(object):
         signals_conns = model.get_signals_to_object(self)[InputPort.standard]
         filter_region, filter_routing_region = make_filter_regions(
             signals_conns, model.dt, True, model.keyspaces.filter_routing_tag)
+        self._routing_region = filter_routing_region
 
         # Make sufficient vertices to ensure that each has a size_in of less
         # than max_width.
@@ -73,6 +74,18 @@ class ValueSink(object):
         # Return the spec
         return netlistspec(self.vertices, self.load_to_machine,
                            after_simulation_function=self.after_simulation)
+
+    def get_signal_constraints(self):
+        """Return a set of constraints on which signal parameters may share the
+        same keyspace.
+
+        Returns
+        -------
+        {id(SignalParameters): {id(SignalParameters), ...}}
+            A (moderately unpleasant) dictionary of which signal parameters
+            cannot share a routing identifier.
+        """
+        return self._routing_region.get_signal_constraints()
 
     def load_to_machine(self, netlist, controller):
         """Load the ensemble data into memory."""

--- a/nengo_spinnaker/regions/filters.py
+++ b/nengo_spinnaker/regions/filters.py
@@ -1,5 +1,5 @@
 import collections
-from itertools import combinations
+from itertools import combinations, product
 import nengo.synapses
 from nengo.utils.filter_design import cont2discrete
 import numpy as np
@@ -343,9 +343,10 @@ class FilterRoutingRegion(Region):
         # The signals in different target-sets cannot share routing identifiers
         constraints = collections.defaultdict(set)
         for xs, ys in combinations(itervalues(targets_to_ids), 2):
-            for x, y in ((i, j) for j in ys for i in xs if i != j):
-                constraints[x].add(y)
-                constraints[y].add(x)
+            for x, y in product(xs, ys):
+                if x != y:
+                    constraints[x].add(y)
+                    constraints[y].add(x)
 
         return constraints
 

--- a/nengo_spinnaker/regions/filters.py
+++ b/nengo_spinnaker/regions/filters.py
@@ -333,7 +333,8 @@ class FilterRoutingRegion(Region):
         # target.
         id_to_targets = collections.defaultdict(list)
         for signal, target in self.signal_routes:
-            id_to_targets[id(signal)].append(target)
+            if signal.keyspace is None:
+                id_to_targets[id(signal)].append(target)
 
         # Invert this to build a map of targets to signals
         targets_to_ids = collections.defaultdict(list)

--- a/tests/builder/test_builder.py
+++ b/tests/builder/test_builder.py
@@ -468,7 +468,7 @@ class TestMakeNetlist(object):
         constraint_a = mock.Mock(name="Constraint B")
 
         object_a = mock.Mock(name="object A")
-        operator_a = mock.Mock(name="operator A")
+        operator_a = mock.Mock(name="operator A", spec_set=["make_vertices"])
         operator_a.make_vertices.return_value = \
             netlistspec(vertex_a, load_fn_a, pre_fn_a, post_fn_a,
                         constraint_a)
@@ -479,7 +479,7 @@ class TestMakeNetlist(object):
         constraint_b = mock.Mock(name="Constraint B")
 
         object_b = mock.Mock(name="object B")
-        operator_b = mock.Mock(name="operator B")
+        operator_b = mock.Mock(name="operator B", spec_set=["make_vertices"])
         operator_b.make_vertices.return_value = \
             netlistspec(vertex_b, load_fn_b, constraints=[constraint_b])
 
@@ -528,12 +528,12 @@ class TestMakeNetlist(object):
         pre_fn_a = mock.Mock(name="pre function A")
         post_fn_a = mock.Mock(name="post function A")
 
-        operator_a = mock.Mock(name="operator A")
+        operator_a = mock.Mock(name="operator A", spec_set=["make_vertices"])
         operator_a.make_vertices.return_value = \
             netlistspec(vertex_a, load_fn_a, pre_fn_a, post_fn_a)
 
         # Create the second operator
-        object_b = mock.Mock(name="object B")
+        object_b = mock.Mock(name="object B", spec_set=["make_vertices"])
         operator_b = operators.Filter(16)  # Shouldn't need building
 
         # Create the model, add the items and add an entry to the connection
@@ -561,7 +561,7 @@ class TestMakeNetlist(object):
         pre_fn_a = mock.Mock(name="pre function A")
         post_fn_a = mock.Mock(name="post function A")
 
-        operator_a = mock.Mock(name="operator A")
+        operator_a = mock.Mock(name="operator A", spec_set=["make_vertices"])
         operator_a.make_vertices.return_value = \
             netlistspec(vertex_a, load_fn_a, pre_fn_a, post_fn_a)
 
@@ -569,7 +569,7 @@ class TestMakeNetlist(object):
         vertex_b = mock.Mock(name="vertex B")
         load_fn_b = mock.Mock(name="load function B")
 
-        operator_b = mock.Mock(name="operator B")
+        operator_b = mock.Mock(name="operator B", spec_set=["make_vertices"])
         operator_b.make_vertices.return_value = \
             netlistspec(vertex_b, load_fn_b)
 
@@ -604,7 +604,7 @@ class TestMakeNetlist(object):
         post_fn_a = mock.Mock(name="post function A")
 
         object_a = mock.Mock(name="object A")
-        operator_a = mock.Mock(name="operator A")
+        operator_a = mock.Mock(name="operator A", spec_set=["make_vertices"])
         operator_a.make_vertices.return_value = \
             netlistspec(vertex_a, load_fn_a, pre_fn_a, post_fn_a)
 
@@ -614,7 +614,7 @@ class TestMakeNetlist(object):
         load_fn_b = mock.Mock(name="load function B")
 
         object_b = mock.Mock(name="object B")
-        operator_b = mock.Mock(name="operator B")
+        operator_b = mock.Mock(name="operator B", spec_set=["make_vertices"])
         operator_b.make_vertices.return_value = \
             netlistspec([vertex_b0, vertex_b1], load_fn_b)
 
@@ -623,7 +623,7 @@ class TestMakeNetlist(object):
         vertex_c.accepts_signal.side_effect = lambda _, __: False
 
         object_c = mock.Mock(name="object C")
-        operator_c = mock.Mock(name="operator C")
+        operator_c = mock.Mock(name="operator C", spec_set=["make_vertices"])
         operator_c.make_vertices.return_value = netlistspec(vertex_c)
 
         # Create a signal between the operators
@@ -687,7 +687,7 @@ class TestMakeNetlist(object):
         post_fn_a = mock.Mock(name="post function A")
 
         object_a = mock.Mock(name="object A")
-        operator_a = mock.Mock(name="operator A")
+        operator_a = mock.Mock(name="operator A", spec_set=["make_vertices"])
         operator_a.make_vertices.return_value = \
             netlistspec([vertex_a0, vertex_a1, vertex_a2],
                         load_fn_a, pre_fn_a, post_fn_a)
@@ -697,7 +697,7 @@ class TestMakeNetlist(object):
         load_fn_b = mock.Mock(name="load function B")
 
         object_b = mock.Mock(name="object B")
-        operator_b = mock.Mock(name="operator B")
+        operator_b = mock.Mock(name="operator B", spec_set=["make_vertices"])
         operator_b.make_vertices.return_value = \
             netlistspec(vertex_b, load_fn_b)
 

--- a/tests/regions/test_filters.py
+++ b/tests/regions/test_filters.py
@@ -367,17 +367,35 @@ def test_filter_routing_region_duplicate_connection():
         index_field="index"
     )
 
-    # Extract a dictionary of the constraints on the signal keys
-    assert filter_region.get_signal_constraints() == {
-        id(sig_a): {id(sig_b)},
-        id(sig_b): {id(sig_a)},
-    }
+    # Extract a dictionary of the constraints on the signal keys (no
+    # constraints because the keyspace was specified before).
+    assert len(filter_region.get_signal_constraints()) == 0
 
     # Check that an error is raised because two signals with the same key route
     # in different directions
     fp = tempfile.TemporaryFile()
     with pytest.raises(AssertionError):
         filter_region.write_subregion_to_file(fp)
+
+
+def test_filter_routing_region_get_signal_constraints():
+    """Test the reporting of which signals cannot share a routing identifier.
+    """
+    # Define some signals
+    sig_a = SignalParameters()
+    sig_b = SignalParameters()
+
+    # Define the filter routes, these map a keyspace to an integer
+    signal_routes = [(sig_a, 12), (sig_b, 12), (sig_b, 17)]
+
+    # Create the region
+    filter_region = FilterRoutingRegion(signal_routes)
+
+    # Extract a dictionary of the constraints on the signal keys
+    assert filter_region.get_signal_constraints() == {
+        id(sig_a): {id(sig_b)},
+        id(sig_b): {id(sig_a)},
+    }
 
 
 class TestMakeFilterRegions(object):

--- a/tests/regions/test_filters.py
+++ b/tests/regions/test_filters.py
@@ -367,6 +367,12 @@ def test_filter_routing_region_duplicate_connection():
         index_field="index"
     )
 
+    # Extract a dictionary of the constraints on the signal keys
+    assert filter_region.get_signal_constraints() == {
+        id(sig_a): {id(sig_b)},
+        id(sig_b): {id(sig_a)},
+    }
+
     # Check that an error is raised because two signals with the same key route
     # in different directions
     fp = tempfile.TemporaryFile()


### PR DESCRIPTION
This improves (and builds upon) #133 by allowing the same keys to be used by signals which target the same filter models in the same operators. The result is that yet fewer unique signal identifiers are used and that the filter routing table gets smaller, reducing the compute cost of receiving and processing a multicast packet.
- [x] More testing of this with larger and complex models.
