### PR TITLE
Transforms must be C-contiguous

### DIFF
--- a/nengo_spinnaker/builder/connection.py
+++ b/nengo_spinnaker/builder/connection.py
@@ -37,7 +37,7 @@ def build_generic_reception_params(model, conn):
 class TransmissionParameters(object):
     """Parameters describing generic connections."""
     def __init__(self, transform):
-        self.transform = np.array(transform)
+        self.transform = np.array(transform, order='C')
         self.transform.flags['WRITEABLE'] = False
 
     def __ne__(self, other):


### PR DESCRIPTION
Fixes a bug which prevented hashing of arrays under Python 3.
