### PR TITLE
Reduce duplication of filter routing effort

### DIFF
--- a/nengo_spinnaker/operators/filter.py
+++ b/nengo_spinnaker/operators/filter.py
@@ -150,6 +150,9 @@ class Filter(object):
 
     def load_to_machine(self, netlist, controller):
         """Load the data to the machine."""
+        # Prepare the filter routing region
+        self._routing_region.build_routes()
+
         # Get each group to load itself
         for g in self.groups:
             g.load_to_machine(netlist, controller)

--- a/nengo_spinnaker/operators/lif.py
+++ b/nengo_spinnaker/operators/lif.py
@@ -63,6 +63,12 @@ class Regions(enum.IntEnum):
     encoder_recording = 25
 
 
+RoutingRegions = (Regions.input_routing,
+                  Regions.inhibition_routing,
+                  Regions.modulatory_routing,
+                  Regions.learnt_encoder_routing)
+
+
 class EnsembleLIF(object):
     """Controller for an ensemble of LIF neurons."""
     def __init__(self, ensemble):
@@ -480,10 +486,7 @@ class EnsembleLIF(object):
         # routing identifier. Build a mapping from signal to the sets of
         # routing regions they target.
         signal_regions = collections.defaultdict(set)
-        for region in (Regions.inhibition_routing,
-                       Regions.learnt_encoder_routing,
-                       Regions.modulatory_routing,
-                       Regions.input_routing):
+        for region in RoutingRegions:
             # Grab the regions targeted by the keyspace
             for signal, _ in self.regions[region].signal_routes:
                 if signal.keyspace is None:
@@ -513,6 +516,10 @@ class EnsembleLIF(object):
 
     def load_to_machine(self, netlist, controller):
         """Load the ensemble data into memory."""
+        # Prepare the routing regions
+        for region in RoutingRegions:
+            self.regions[region].build_routes()
+
         # Delegate the task of loading to the machine
         for cluster in self.clusters:
             cluster.load_to_machine(netlist, controller)

--- a/nengo_spinnaker/operators/sdp_transmitter.py
+++ b/nengo_spinnaker/operators/sdp_transmitter.py
@@ -62,6 +62,9 @@ class SDPTransmitter(object):
 
     def load_to_machine(self, netlist, controller):
         """Load data to the machine."""
+        # Prepare the filter routing region
+        self._routing_region.build_routes()
+
         # Get the memory
         sys_mem, filter_mem, routing_mem = \
             region_utils.create_app_ptr_and_region_files(

--- a/nengo_spinnaker/operators/value_sink.py
+++ b/nengo_spinnaker/operators/value_sink.py
@@ -89,6 +89,9 @@ class ValueSink(object):
 
     def load_to_machine(self, netlist, controller):
         """Load the ensemble data into memory."""
+        # Prepare the filter routing region
+        self._routing_region.build_routes()
+
         # Load each vertex in turn
         for v in self.vertices:
             v.load_to_machine(netlist)

--- a/tests/regions/test_filters.py
+++ b/tests/regions/test_filters.py
@@ -320,6 +320,7 @@ def test_filter_routing_region():
 
     # Check that the written out data is sensible
     fp = tempfile.TemporaryFile()
+    filter_region.build_routes()
     filter_region.write_subregion_to_file(fp)
 
     # Check that the data is sensible
@@ -375,7 +376,7 @@ def test_filter_routing_region_duplicate_connection():
     # in different directions
     fp = tempfile.TemporaryFile()
     with pytest.raises(AssertionError):
-        filter_region.write_subregion_to_file(fp)
+        filter_region.build_routes()
 
 
 def test_filter_routing_region_get_signal_constraints():


### PR DESCRIPTION
The filter routing table was previously (stupidly) generated for each vertex that existed rather than being generated once for the operator. This commit adds a new method (build_routes) to the region to allow the routing table to be generated once only.
