### PR TITLE
Minimise filter routing regions

### DIFF
--- a/nengo_spinnaker/operators/filter.py
+++ b/nengo_spinnaker/operators/filter.py
@@ -151,7 +151,7 @@ class Filter(object):
     def load_to_machine(self, netlist, controller):
         """Load the data to the machine."""
         # Prepare the filter routing region
-        self._routing_region.build_routes()
+        self._routing_region.build_routes(minimise=True)
 
         # Get each group to load itself
         for g in self.groups:

--- a/nengo_spinnaker/operators/sdp_transmitter.py
+++ b/nengo_spinnaker/operators/sdp_transmitter.py
@@ -63,7 +63,7 @@ class SDPTransmitter(object):
     def load_to_machine(self, netlist, controller):
         """Load data to the machine."""
         # Prepare the filter routing region
-        self._routing_region.build_routes()
+        self._routing_region.build_routes(minimise=True)
 
         # Get the memory
         sys_mem, filter_mem, routing_mem = \

--- a/nengo_spinnaker/operators/value_sink.py
+++ b/nengo_spinnaker/operators/value_sink.py
@@ -90,7 +90,7 @@ class ValueSink(object):
     def load_to_machine(self, netlist, controller):
         """Load the ensemble data into memory."""
         # Prepare the filter routing region
-        self._routing_region.build_routes()
+        self._routing_region.build_routes(minimise=True)
 
         # Load each vertex in turn
         for v in self.vertices:

--- a/nengo_spinnaker/regions/filters.py
+++ b/nengo_spinnaker/regions/filters.py
@@ -375,7 +375,8 @@ class FilterRoutingRegion(Region):
             # Include this in the set of targets to keymasks
             targets_to_keymasks[(dmask, tuple(sorted(targets)))].add(keymask)
 
-        # Assert that the sets of keymasks are disjoint
+        # Assert that no key/mask combination appears in the list of keys and
+        # masks of two separate sets of targets.
         keymask_sets = list(itervalues(targets_to_keymasks))
         for a, b in combinations(keymask_sets, 2):
             assert a.isdisjoint(b)
@@ -384,11 +385,11 @@ class FilterRoutingRegion(Region):
         # associated with it, this off-set is formed as the union of the sets
         # of keys and masks which are intended to match against all other
         # targets.
-        offsets = collections.defaultdict(set)
+        off_sets = collections.defaultdict(set)
         for target_set in iterkeys(targets_to_keymasks):
             for other_target_set, keymasks in iteritems(targets_to_keymasks):
                 if target_set != other_target_set:
-                    offsets[target_set].update(keymasks)
+                    off_sets[target_set].update(keymasks)
 
         # (Minimise) and build the routing entries.
         self.filter_routes = list()
@@ -396,7 +397,7 @@ class FilterRoutingRegion(Region):
             for target in targets:
                 all_keymasks = (
                     keymasks if not minimise else
-                    ccf_minimise(keymasks, offsets[(dmask, targets)])
+                    ccf_minimise(keymasks, off_sets[(dmask, targets)])
                 )
 
                 # Write in an entry for each key and mask as usual

--- a/nengo_spinnaker/utils/ccf.py
+++ b/nengo_spinnaker/utils/ccf.py
@@ -1,0 +1,115 @@
+def minimise(on_set, off_set, used_columns=set()):
+    """Minimise a set of keys and masks.
+
+    Parameters
+    ----------
+    on_set : {(key, mask), ...}
+        Set of keys and masks to minimise.
+    off_set : {(key, mask), ...}
+        Set of keys and masks which should *not* be covered by the minimised
+        version of the "on-set".
+
+    Returns
+    -------
+    {(key, mask), ...}
+        A set of keys and masks which covers all the terms in the on-set while
+        covering none of the terms in the off-set.
+
+    Uses the "Critical Column First" algorithm presented by:
+
+        Yang, Ze, and Kwan L. Yeung. "An efficient flow monitoring algorithm
+        using a flexible match structure." High Performance Switching and
+        Routing (HPSR), 2016 IEEE 17th International Conference on. IEEE, 2016.
+    """
+    # Copy the set of columns that have been chosen already
+    used_columns = {x for x in used_columns}
+
+    if len(off_set) == 0:
+        # If there is no off-set then yield a key and mask combination which
+        # will match everything in the on-set.
+        any_ones = 0x00000000  # Bits which are 1 in any entry
+        all_ones = 0xffffffff  # Bits which are 1 in all entries
+        all_selected = 0xffffffff  # Bits which are 1 in all masks
+
+        # Determine which bits to set to 0, 1 and X
+        for key, mask in on_set:
+            any_ones |= key
+            all_ones &= key
+            all_selected &= mask
+
+        any_zeros = ~all_ones
+        new_xs = any_ones ^ any_zeros
+
+        mask = new_xs & all_selected  # Combine new Xs with existing Xs
+        key = all_ones & mask
+        yield key, mask
+    else:
+        # Otherwise determine a column that can be used to break the on- and
+        # off-sets apart.
+        on_xs, on_zeros, on_ones = _count_bits(on_set)
+        off_xs, off_zeros, off_ones = _count_bits(off_set)
+
+        no_xs = tuple(not(a or b) for a, b in zip(on_xs, off_xs))
+        zeros = tuple(a - b for a, b in zip(on_zeros, off_zeros))
+        ones = tuple(a - b for a, b in zip(on_ones, off_ones))
+        scores = tuple(max(p0, p1) for p0, p1 in zip(zeros, ones))
+
+        # Get the best column
+        best_column = None
+        for i, (score, valid) in enumerate(zip(scores, no_xs)):
+            if valid and i not in used_columns:
+                if best_column is None or scores[best_column] < score:
+                    best_column = i
+
+        # Break the entries apart based on the value of this column
+        new_on_set_zeros, new_on_set_ones = _break_set(on_set, best_column)
+        new_off_set_zeros, new_off_set_ones = _break_set(off_set, best_column)
+
+        used_columns.add(best_column)  # Mark the column as used
+
+        if len(new_on_set_zeros) >= 1:
+            for entry in minimise(new_on_set_zeros, new_off_set_zeros,
+                                  used_columns):
+                yield entry
+
+        if len(new_on_set_ones) >= 1:
+            for entry in minimise(new_on_set_ones, new_off_set_ones,
+                                  used_columns):
+                yield entry
+
+
+def _count_bits(entries):
+    xs = [False for _ in range(32)]
+    zeros = [0 for _ in range(32)]
+    ones = [0 for _ in range(32)]
+
+    for key, mask in entries:
+        for i in range(32):
+            bit = 1 << i
+
+            if mask & bit:
+                if not key & bit:
+                    zeros[i] += 1
+                else:
+                    ones[i] += 1
+            else:
+                xs[i] = True
+
+    return tuple(xs), tuple(zeros), tuple(ones)
+
+
+def _break_set(entries, bit):
+    zeros = set()
+    ones = set()
+
+    bit = 1 << bit  # Select the bit
+
+    for key, mask in entries:
+        assert mask & bit
+
+        if not key & bit:
+            zeros.add((key, mask))
+        else:
+            ones.add((key, mask))
+
+    return tuple(zeros), tuple(ones)

--- a/nengo_spinnaker/utils/ccf.py
+++ b/nengo_spinnaker/utils/ccf.py
@@ -67,12 +67,12 @@ def minimise(on_set, off_set, used_columns=set()):
 
         used_columns.add(best_column)  # Mark the column as used
 
-        if len(new_on_set_zeros) >= 1:
+        if len(new_on_set_zeros) > 0:
             for entry in minimise(new_on_set_zeros, new_off_set_zeros,
                                   used_columns):
                 yield entry
 
-        if len(new_on_set_ones) >= 1:
+        if len(new_on_set_ones) > 0:
             for entry in minimise(new_on_set_ones, new_off_set_ones,
                                   used_columns):
                 yield entry

--- a/tests/utils/test_ccf.py
+++ b/tests/utils/test_ccf.py
@@ -1,0 +1,63 @@
+from nengo_spinnaker.utils.ccf import minimise
+import pytest
+
+
+@pytest.mark.parametrize(
+    "on_set",
+    [{(0b00, 0b11), (0b01, 0b11)},  # 0 and 0 => 0, 0 and 1 => X
+     {(0b10, 0b11), (0b11, 0b11)},  # 1 and 1 => 1, 0 and 1 => X
+     {(0b0, 0b1), (0b0, 0b0)},  # 0 and X => X
+     {(0b1, 0b1), (0b0, 0b0)},  # 1 and X => X
+     {(0b0, 0b0), (0b0, 0b0)},  # X and X => X
+     ])
+def test_leaf_with_no_offset(on_set):
+    """Check that minimising a leaf with no off-set yields a single entry which
+    combining the elements of the on-set.
+    """
+    minimised = set(minimise(on_set, {}))
+
+    # Check that all of the original keys match against the minimised set
+    for key, _ in on_set:
+        assert any(key & mask == ekey for ekey, mask in minimised)
+
+
+@pytest.mark.parametrize(
+    "on_set, off_set, expected",
+    [({(0b00, 0b11), (0b01, 0b11)},
+      {(0b10, 0b11)},
+      {(0b00, 0b10)}),
+     ({(0b01, 0b11), (0b11, 0b11)},
+      {(0b00, 0b11)},
+      {(0b01, 0b01)}),
+     ])
+def test_choose_column_and_empty_column(on_set, off_set, expected):
+    """Test that a column containing more 0s or 1s is chosen and that the empty
+    other column is handled appropriately."""
+    assert set(minimise(on_set, off_set)) == expected
+
+
+def test_no_rechoose_column():
+    """Test that a column is not repeatedly chosen (leading to infinite
+    recursion).
+    """
+    on_set = {(0b000, 0b111),
+              (0b001, 0b111),
+              (0b010, 0b111),
+              (0b111, 0b111)}
+    off_set = {(0b011, 0b111)}
+
+    assert set(minimise(on_set, off_set)) == {
+        (0b000, 0b101),
+        (0b001, 0b111),
+        (0b111, 0b111),
+    }
+
+
+def test_with_xs():
+    """Test that a column containing Xs isn't selected as the column on which
+    to split.
+    """
+    on_set = {(0b1010, 0b1110)}
+    off_set = {(0b1000, 0b1110),
+               (0b0110, 0b1110)}
+    minimised = set(minimise(on_set, off_set))


### PR DESCRIPTION
Reduce the time taken to process some received multicast packets by reducing the number of entries stored in the filter routing regions. The "Critical Column First" minimisation method [[1](http://dx.doi.org/10.1109/HPSR.2016.7525663)] is used to achieve this as it can, unlike "Ordered Covering" (see Rig), be used to minimise unordered sets of routing keys.

Should further minimisation be necessary then a change to the way the routing information is stored by each core may be necessary.

**Note:** The routing regions of ensembles cannot be minimised (currently) because the sets of keys they expect may intersect. This said, the motivating case for filter routing table minimisation is typically on passthrough nodes/interposers.
