### PR TITLE
Minimise ensemble filter routing regions

### DIFF
--- a/nengo_spinnaker/operators/lif.py
+++ b/nengo_spinnaker/operators/lif.py
@@ -525,15 +525,16 @@ class EnsembleLIF(object):
         }
 
         # Hence build the set of keys and masks which should NOT match against
-        # each routing region.
+        # each routing region. Do this by building a set of all the expected
+        # keys and masks and then subtracting from that set the ones which are
+        # expected to match in each region.
         off_sets = collections.defaultdict(set)
         for a, on_set in iteritems(on_sets):
-            for b in RoutingRegions:
-                # Add the on-set for this region `b` to the off-set
-                off_sets[a].update(on_sets[b])
+            for off_set in itervalues(on_sets):
+                off_sets[a].update(off_set)
 
             # Elements which are in the on-set for `a` cannot be in the off-set
-            off_sets[a].difference_update(on_sets[a])
+            off_sets[a].difference_update(on_set)
 
         # Build the filter routing region, minimising the entries subject to
         # the off-sets which were just constructed.

--- a/tests/regions/test_filters.py
+++ b/tests/regions/test_filters.py
@@ -318,6 +318,14 @@ def test_filter_routing_region():
     # Check that the memory requirement is sane
     assert filter_region.sizeof() == 4 * (1 + 4*len(signal_routes))
 
+    # Check that the set of expected keys and masks can be extracted
+    assert filter_region.get_expected_keys_and_masks() == {
+        (ks_a.get_value(tag=ksc.filter_routing_tag),
+         ks_a.get_mask(tag=ksc.filter_routing_tag)),
+        (ks_b.get_value(tag=ksc.filter_routing_tag),
+         ks_b.get_mask(tag=ksc.filter_routing_tag)),
+    }
+
     # Check that the written out data is sensible
     fp = tempfile.TemporaryFile()
     filter_region.build_routes()


### PR DESCRIPTION
Extend the minimisation of filter routing tables to also work for
ensembles. Each filter routing region reports the set of keys and masks
it contains and these form the "off-set"s against which other regions
are minimised.
