### PR TITLE
Graph colouring cluster ids

### DIFF
--- a/nengo_spinnaker/builder/builder.py
+++ b/nengo_spinnaker/builder/builder.py
@@ -319,7 +319,6 @@ class Model(object):
 
         # Call each operator to make vertices
         operator_vertices = dict()
-        vertices = collections_ext.flatinsertionlist()
         load_functions = collections_ext.noneignoringlist()
         before_simulation_functions = collections_ext.noneignoringlist()
         after_simulation_functions = collections_ext.noneignoringlist()
@@ -340,8 +339,10 @@ class Model(object):
                 self, *args, **kwargs
             )
 
-            operator_vertices[op] = vxs
-            vertices.append(vxs)
+            if isinstance(vxs, (list, tuple, set)):
+                operator_vertices[op] = tuple(vxs)
+            else:
+                operator_vertices[op] = (vxs, )
 
             load_functions.append(load_fn)
             before_simulation_functions.append(pre_fn)
@@ -365,14 +366,6 @@ class Model(object):
                     if u != v:
                         id_constraints[u].add(v)
                         id_constraints[v].add(u)
-
-        # Construct the groups set
-        groups = list()
-        for vxs in itervalues(operator_vertices):
-            # If multiple vertices were provided by an operator then we add
-            # them as a new group.
-            if isinstance(vxs, collections.Iterable):
-                groups.append(set(vxs))
 
         # Construct nets from the signals
         nets = dict()
@@ -429,9 +422,8 @@ class Model(object):
         # Return a netlist
         return Netlist(
             nets=nets,
-            vertices=vertices,
+            operator_vertices=operator_vertices,
             keyspaces=self.keyspaces,
-            groups=groups,
             constraints=constraints,
             load_functions=load_functions,
             before_simulation_functions=before_simulation_functions,

--- a/nengo_spinnaker/builder/builder.py
+++ b/nengo_spinnaker/builder/builder.py
@@ -334,15 +334,11 @@ class Model(object):
                 continue
 
             # Otherwise call upon the operator to build vertices for the
-            # netlist.
+            # netlist. The vertices should always be returned as an iterable.
             vxs, load_fn, pre_fn, post_fn, constraint = op.make_vertices(
                 self, *args, **kwargs
             )
-
-            if isinstance(vxs, (list, tuple, set)):
-                operator_vertices[op] = tuple(vxs)
-            else:
-                operator_vertices[op] = (vxs, )
+            operator_vertices[op] = tuple(vxs)
 
             load_functions.append(load_fn)
             before_simulation_functions.append(pre_fn)

--- a/nengo_spinnaker/netlist/netlist.py
+++ b/nengo_spinnaker/netlist/netlist.py
@@ -135,10 +135,6 @@ class Netlist(object):
                                     constraints, self.placements,
                                     **allocate_kwargs)
 
-        # Identify clusters and modify vertices appropriately
-        utils.identify_clusters(itervalues(self.operator_vertices),
-                                self.placements)
-
         # Get the nets for routing
         (route_nets,
          vertices_resources,  # Can safely overwrite the resource dictionary
@@ -162,6 +158,11 @@ class Netlist(object):
         key_allocation.allocate_signal_keyspaces(signal_routes,
                                                  self.signal_id_constraints,
                                                  self.keyspaces)
+
+        # Assign cluster IDs based on the placement and the routing
+        key_allocation.assign_cluster_ids(self.operator_vertices,
+                                          signal_routes,
+                                          self.placements)
 
         # Get a map from the nets we will route with to keyspaces
         self.net_keyspaces = utils.get_net_keyspaces(

--- a/nengo_spinnaker/netlist/utils.py
+++ b/nengo_spinnaker/netlist/utils.py
@@ -85,56 +85,6 @@ def get_nets_for_routing(resources, nets, placements, allocations):
             extended_allocations, derived_nets)
 
 
-def identify_clusters(groups, placements):
-    """Group vertices in clusters (based on chip assignation).
-
-    A vertex may be partitioned into a number of vertex slices which are placed
-    onto the cores of two SpiNNaker chips.  The vertex slices on these chips
-    form two clusters; packets from these clusters need to be differentiated in
-    order to route packets correctly.  For example::
-
-       +--------+                      +--------+
-       |        | ------- (a) ------>  |        |
-       |   (A)  |                      |   (B)  |
-       |        | <------ (b) -------  |        |
-       +--------+                      +--------+
-
-    Packets traversing `(a)` need to be differentiated from packets traversing
-    `(b)`.  This can be done by including an additional field in the packet
-    keys which indicates from which chip the packet was sent - in this case a
-    single bit will suffice with packets from `(A)` using a key with the bit
-    not set and packets from `(B)` setting the bit.
-
-    This method will assign a unique ID to each cluster of vertices (e.g.,
-    `(A)` and `(B)`) by storing the index in the `cluster` attribute of each
-    subvertex. Later this ID can be used in the keyspace of all nets
-    originating from the cluster.
-
-    Parameters
-    ----------
-    groups : [{Vertex, ...}, ...]
-        List of groups of vertices. This is used to identify objects which may
-        be joined into a cluster.
-    placements : {vertex: (x, y), ...}
-    """
-    # Perform clustering for each group of vertices in turn.
-    for group in groups:
-        # Build a map of placements to vertices, this will be used to identify
-        # clusters.
-        clusters = collections.defaultdict(list)  # Map co-ordinate to cluster
-
-        # Add each vertex in the group to a cluster.
-        for vertex in group:
-            coord = placements[vertex]
-            clusters[coord].append(vertex)
-
-        # Assign a unique ID to each cluster in the group
-        for cluster_id, cluster in enumerate(itervalues(clusters)):
-            # Store the cluster ID in each vertex in the cluster
-            for vertex in cluster:
-                vertex.cluster = cluster_id
-
-
 def get_net_keyspaces(placements, nets, derived_nets):
     """Get a map from the nets used during routing to the keyspaces (NOT the
     keys and masks) that should be used when building routing tables.

--- a/nengo_spinnaker/operators/sdp_transmitter.py
+++ b/nengo_spinnaker/operators/sdp_transmitter.py
@@ -45,7 +45,7 @@ class SDPTransmitter(object):
         self._vertex = Vertex(get_application("tx"), resources)
 
         # Return the netlist specification
-        return netlistspec(self._vertex,
+        return netlistspec((self._vertex, ),  # Tuple is required
                            load_function=self.load_to_machine)
 
     def get_signal_constraints(self):

--- a/tests/builder/test_builder.py
+++ b/tests/builder/test_builder.py
@@ -470,7 +470,7 @@ class TestMakeNetlist(object):
         object_a = mock.Mock(name="object A")
         operator_a = mock.Mock(name="operator A", spec_set=["make_vertices"])
         operator_a.make_vertices.return_value = \
-            netlistspec(vertex_a, load_fn_a, pre_fn_a, post_fn_a,
+            netlistspec((vertex_a, ), load_fn_a, pre_fn_a, post_fn_a,
                         constraint_a)
 
         # Create the second operator
@@ -481,7 +481,7 @@ class TestMakeNetlist(object):
         object_b = mock.Mock(name="object B")
         operator_b = mock.Mock(name="operator B", spec_set=["make_vertices"])
         operator_b.make_vertices.return_value = \
-            netlistspec(vertex_b, load_fn_b, constraints=[constraint_b])
+            netlistspec((vertex_b, ), load_fn_b, constraints=[constraint_b])
 
         # Create a signal between the operators
         keyspace = mock.Mock(name="keyspace")
@@ -533,7 +533,7 @@ class TestMakeNetlist(object):
 
         operator_a = mock.Mock(name="operator A", spec_set=["make_vertices"])
         operator_a.make_vertices.return_value = \
-            netlistspec(vertex_a, load_fn_a, pre_fn_a, post_fn_a)
+            netlistspec((vertex_a, ), load_fn_a, pre_fn_a, post_fn_a)
 
         # Create the second operator
         object_b = mock.Mock(name="object B", spec_set=["make_vertices"])
@@ -566,7 +566,7 @@ class TestMakeNetlist(object):
 
         operator_a = mock.Mock(name="operator A", spec_set=["make_vertices"])
         operator_a.make_vertices.return_value = \
-            netlistspec(vertex_a, load_fn_a, pre_fn_a, post_fn_a)
+            netlistspec((vertex_a, ), load_fn_a, pre_fn_a, post_fn_a)
 
         # Create the second operator
         vertex_b = mock.Mock(name="vertex B")
@@ -574,7 +574,7 @@ class TestMakeNetlist(object):
 
         operator_b = mock.Mock(name="operator B", spec_set=["make_vertices"])
         operator_b.make_vertices.return_value = \
-            netlistspec(vertex_b, load_fn_b)
+            netlistspec((vertex_b, ), load_fn_b)
 
         # Create the model, add the items and then generate the netlist
         model = Model()
@@ -611,7 +611,7 @@ class TestMakeNetlist(object):
         object_a = mock.Mock(name="object A")
         operator_a = mock.Mock(name="operator A", spec_set=["make_vertices"])
         operator_a.make_vertices.return_value = \
-            netlistspec(vertex_a, load_fn_a, pre_fn_a, post_fn_a)
+            netlistspec((vertex_a, ), load_fn_a, pre_fn_a, post_fn_a)
 
         # Create the second operator
         vertex_b0 = mock.Mock(name="vertex B0")
@@ -629,7 +629,7 @@ class TestMakeNetlist(object):
 
         object_c = mock.Mock(name="object C")
         operator_c = mock.Mock(name="operator C", spec_set=["make_vertices"])
-        operator_c.make_vertices.return_value = netlistspec(vertex_c)
+        operator_c.make_vertices.return_value = netlistspec((vertex_c, ))
 
         # Create a signal between the operators
         keyspace = mock.Mock(name="keyspace")
@@ -704,7 +704,7 @@ class TestMakeNetlist(object):
         object_b = mock.Mock(name="object B")
         operator_b = mock.Mock(name="operator B", spec_set=["make_vertices"])
         operator_b.make_vertices.return_value = \
-            netlistspec(vertex_b, load_fn_b)
+            netlistspec((vertex_b, ), load_fn_b)
 
         # Create a signal between the operators
         keyspace = mock.Mock(name="keyspace")

--- a/tests/builder/test_builder.py
+++ b/tests/builder/test_builder.py
@@ -509,9 +509,12 @@ class TestMakeNetlist(object):
             assert net.sinks == [vertex_b]
             assert net.weight == signal_ab_parameters.weight
 
-        assert set(netlist.vertices) == set([vertex_a, vertex_b])
+        assert netlist.operator_vertices == {
+            operator_a: (vertex_a, ),
+            operator_b: (vertex_b, ),
+        }
+
         assert netlist.keyspaces is model.keyspaces
-        assert netlist.groups == list()
         assert set(netlist.constraints) == set([constraint_a, constraint_b])
         assert set(netlist.load_functions) == set([load_fn_a, load_fn_b])
         assert netlist.before_simulation_functions == [pre_fn_a]
@@ -549,7 +552,7 @@ class TestMakeNetlist(object):
 
         # The netlist should contain vertex a and no nets
         assert len(netlist.nets) == 0
-        assert netlist.vertices == [vertex_a]
+        assert netlist.operator_vertices == {operator_a: (vertex_a, )}
 
     def test_extra_operators_and_signals(self):
         """Test the operators in the extra_operators list are included when
@@ -585,9 +588,11 @@ class TestMakeNetlist(object):
         # Check that the netlist is as expected
         assert len(netlist.nets) == 0
 
-        assert set(netlist.vertices) == set([vertex_a, vertex_b])
+        assert netlist.operator_vertices == {
+            operator_a: (vertex_a, ),
+            operator_b: (vertex_b, ),
+        }
         assert netlist.keyspaces is model.keyspaces
-        assert netlist.groups == list()
         assert len(netlist.constraints) == 0
         assert set(netlist.load_functions) == set([load_fn_a, load_fn_b])
         assert netlist.before_simulation_functions == [pre_fn_a]
@@ -651,16 +656,16 @@ class TestMakeNetlist(object):
         assert vertex_c.accepts_signal.called
 
         # Check that the netlist is as expected
-        assert set(netlist.vertices) == set(
-            [vertex_a, vertex_b0, vertex_b1, vertex_c])
+        assert netlist.operator_vertices == {
+            operator_a: (vertex_a, ),
+            operator_b: (vertex_b0, vertex_b1),
+            operator_c: (vertex_c, ),
+        }
         assert len(netlist.nets) == 1
         for net in itervalues(netlist.nets):
             assert net.sources == [vertex_a]
             assert net.sinks == [vertex_b0, vertex_b1]
             assert net.weight == signal_ab_parameters.weight
-
-        # Check that the groups are correct
-        assert netlist.groups == [set([vertex_b0, vertex_b1])]
 
         assert len(netlist.constraints) == 0
 
@@ -717,14 +722,15 @@ class TestMakeNetlist(object):
         netlist = model.make_netlist()
 
         # Check that the netlist is as expected
-        assert set(netlist.vertices) == set([vertex_a0, vertex_a1,
-                                             vertex_a2, vertex_b])
+        assert netlist.operator_vertices == {
+            operator_a: (vertex_a0, vertex_a1, vertex_a2),
+            operator_b: (vertex_b, ),
+        }
         assert len(netlist.nets) == 1
         for net in itervalues(netlist.nets):
             assert net.sources == [vertex_a0, vertex_a1]
             assert net.sinks == [vertex_b]
 
-        assert netlist.groups == [set([vertex_a0, vertex_a1, vertex_a2])]
         assert len(netlist.constraints) == 0
 
         # Check that `transmit_signal` was called correctly

--- a/tests/netlist/test_netlist_netlist.py
+++ b/tests/netlist/test_netlist_netlist.py
@@ -23,9 +23,8 @@ def test_before_simulation():
     # Create a netlist
     model = netlist.Netlist(
         nets=[],
-        vertices=[vertex],
+        operator_vertices={object(): (vertex, )},
         keyspaces={},
-        groups={},
         load_functions=[],
         before_simulation_functions=[before_a, before_b]
     )
@@ -54,9 +53,8 @@ def test_after_simulation():
     # Create a netlist
     model = netlist.Netlist(
         nets=[],
-        vertices=[],
+        operator_vertices={},
         keyspaces={},
-        groups={},
         load_functions=[],
         after_simulation_functions=[after_a, after_b]
     )

--- a/tests/netlist/test_netlist_utils.py
+++ b/tests/netlist/test_netlist_utils.py
@@ -135,34 +135,6 @@ def test_get_nets_for_routing():
         assert extended_allocations[v] == allocations[v]
 
 
-def test_identify_clusters():
-    """Test the correct assignation of clusters."""
-    # Create two vertices
-    vertex_A = [Vertex() for _ in range(4)]
-    vertex_B = [Vertex() for _ in range(2)]
-
-    # Create placements such that vertex A and B fall on two chips and A[0] and
-    # A[1] are on the same chip.
-    placements = {
-        vertex_A[0]: (0, 0), vertex_A[1]: (0, 0),
-        vertex_A[2]: (0, 1), vertex_A[3]: (0, 1),
-        vertex_B[0]: (0, 0), vertex_B[1]: (1, 0),
-    }
-
-    # Identify groups
-    groups = [set(vertex_A), set(vertex_B)]
-
-    # Identify clusters
-    utils.identify_clusters(groups, placements)
-
-    # Ensure that appropriate cluster indices are assigned to all vertices
-    assert vertex_A[0].cluster == vertex_A[1].cluster  # 1 cluster of A
-    assert vertex_A[2].cluster == vertex_A[3].cluster  # The other
-    assert vertex_A[0].cluster != vertex_A[2].cluster  # Different IDs
-
-    assert vertex_B[0].cluster != vertex_B[1].cluster  # Different IDs
-
-
 def test_get_net_keyspaces():
     """Test the correct specification of keyspaces for nets."""
     # Create the vertices
@@ -178,6 +150,12 @@ def test_get_net_keyspaces():
     }
     resources = {v: {} for v in placements}
     allocations = {v: {} for v in placements}
+
+    # Manually assign cluster IDs
+    vertex_A[0].cluster = 0
+    vertex_A[1].cluster = 0
+    vertex_A[2].cluster = 1
+    vertex_A[3].cluster = 1
 
     # Create a container for the keyspaces
     ksc = KeyspaceContainer()
@@ -196,13 +174,6 @@ def test_get_net_keyspaces():
         signal_b: NMNet(vertex_B, vertex_A, 2.0),
         signal_c: NMNet(vertex_A, vertex_A, 3.0),
     }
-
-    # Identify groups
-    groups = [set(vertex_A)]
-
-    # Identify clusters
-    utils.identify_clusters(groups, placements)
-    assert vertex_B.cluster is None  # Not clustered
 
     # Get the routing nets
     _, _, _, _, derived_nets = utils.get_nets_for_routing(


### PR DESCRIPTION
Cluster IDs are used to ensure the multicast nets representing signals which originate from multiple chips can be differentiated if they take different routes at the same router. Previously each chip was assigned a unique identifier but this is unnecessary and wastes both routing table entries and keyspace.

This PR uses graph colouring to reduce the number of different cluster IDs applied, with the result the fewer bits in the key and fewer routing tables are used to simulate the same model.