### PR TITLE
Fix Simulator/Spalloc usage

### DIFF
--- a/nengo_spinnaker/operators/lif.py
+++ b/nengo_spinnaker/operators/lif.py
@@ -1068,6 +1068,7 @@ class LIFRegion(regions.Region):
             int(self.tau_ref // self.dt)
         ))
 
+
 PESLearningRule = collections.namedtuple(
     "PESLearningRule",
     "learning_rate, error_filter_index, decoder_start, decoder_stop, "
@@ -1128,6 +1129,7 @@ class PESRegion(regions.Region):
         return [l for l in self.learning_rules
                 if (l.decoder_start < learnt_output_slice.stop and
                     l.decoder_stop > learnt_output_slice.start)]
+
 
 VojaLearningRule = collections.namedtuple(
     "VojaLearningRule",

--- a/nengo_spinnaker/scripts/nengo_spinnaker_setup.py
+++ b/nengo_spinnaker/scripts/nengo_spinnaker_setup.py
@@ -70,6 +70,7 @@ def main(args=None):
         print("Successfully created config file in {}".format(filename))
         return 0
 
+
 if __name__ == "__main__":  # pragma: no cover
     import sys
     sys.exit(main())

--- a/nengo_spinnaker/simulator.py
+++ b/nengo_spinnaker/simulator.py
@@ -149,7 +149,7 @@ class Simulator(object):
 
         # Create a controller for the machine and boot if necessary
         self.job = None
-        if not use_spalloc:
+        if not use_spalloc or hostname is not None:
             # Use the specified machine rather than trying to get one
             # allocated.
             if hostname is None:


### PR DESCRIPTION
If the nengo_spinnaker configuration indicates that spalloc then the
simulator ignores a hostname argument if it is provided. This commit
fixes this bug so that the hostname argument takes precedence.