### PR TITLE
Reduce key allocation memory usage

### DIFF
--- a/nengo_spinnaker/netlist/key_allocation.py
+++ b/nengo_spinnaker/netlist/key_allocation.py
@@ -1,5 +1,7 @@
 import logging
 from collections import defaultdict, deque
+from functools import partial
+from nengo_spinnaker.utils.collections import MemberSet
 from six import iteritems, iterkeys, itervalues
 
 logger = logging.getLogger(__name__)
@@ -50,9 +52,12 @@ def assign_mn_net_ids(nets_routes, prior_constraints=None):
     {net: int}
         Mapping from each multiple source net to a valid identifier.
     """
-    return colour_graph(
-        build_mn_net_graph(nets_routes, prior_constraints)
-    )
+    # We construct a type to store lists of vertices
+    NodeSet = partial(MemberSet, tuple(iterkeys(nets_routes)))
+
+    # Build and colour the graph using this type
+    graph = build_mn_net_graph(nets_routes, prior_constraints, NodeSet)
+    return colour_graph(graph, NodeSet)
 
 
 def build_mn_net_graph(nets_routes, prior_constraints=None, NodeSet=set):

--- a/nengo_spinnaker/netlist/key_allocation.py
+++ b/nengo_spinnaker/netlist/key_allocation.py
@@ -55,7 +55,7 @@ def assign_mn_net_ids(nets_routes, prior_constraints=None):
     )
 
 
-def build_mn_net_graph(nets_routes, prior_constraints=None):
+def build_mn_net_graph(nets_routes, prior_constraints=None, NodeSet=set):
     """Build a graph the nodes of which represent multicast nets and the edges
     of which represent constraints upon which nets may share keys.
 
@@ -68,16 +68,21 @@ def build_mn_net_graph(nets_routes, prior_constraints=None):
         Existing constraints to include within the net graph presented as an
         adjacency list.
 
+    Other Parameters
+    ----------------
+    NodeSet : type, optional (default=set)
+        A set-like type used to store the edge list for a node.
+
     Returns
     -------
-    {Net: {Net, ...}, ...}
+    {Net: NodeSet, ...}
         An adjacency list representation of a graph where the presence of an
         edge indicates that two multicast nets may not share a routing key.
     """
     # The different sets of routes from a chip indicate nets which cannot share
     # a routing key, this is indicated by creating an edge between those `nets'
     # in the net graph.
-    net_graph = {net: set() for net in iterkeys(nets_routes)}
+    net_graph = {net: NodeSet() for net in iterkeys(nets_routes)}
 
     # Construct a map from chips to unique sets of routes from that chip to
     # nets which take that route whilst simultaneously using this data
@@ -241,7 +246,7 @@ def build_cluster_graph(signal_routes):
     return cluster_graph
 
 
-def colour_graph(graph):
+def colour_graph(graph, NodeSet=set):
     """Assign colours to each node in a graph such that connected nodes do not
     share a colour.
 
@@ -250,6 +255,11 @@ def colour_graph(graph):
     graph : {node: {node, ...}, ...}
         An adjacency list representation of a graph where the presence of an
         edge indicates that two nodes may not share a colour.
+
+    Other Parameters
+    ----------------
+    NodeSet : type, optional (default=set)
+        A set-like type used to store the nodes should be assigned a colour.
 
     Returns
     -------
@@ -301,12 +311,14 @@ def colour_graph(graph):
                 # a new colour for the node.
                 for group in colours:
                     if graph[node].isdisjoint(group):
-                        group.add(node)
-                        break
+                        break  # `group' represents the selected set
                 else:
                     # Cannot colour this node with any of the existing colours,
                     # so create a new colour.
-                    colours.append({node})
+                    group = NodeSet()
+                    colours.append(group)
+
+                group.add(node)  # Add the node to the set
 
                 # Add unvisited connected nodes to the queue
                 for vx in graph[node]:

--- a/tests/utils/test_collections.py
+++ b/tests/utils/test_collections.py
@@ -81,3 +81,73 @@ def test_counter():
 
     for i in range(10):
         assert counter() == i
+
+
+def test_member_set():
+    # Create two sets with different domains
+    d1 = (1, 2, 3, 4)
+    d2 = (5, 6, 7)
+
+    set1 = nscollections.MemberSet(d1)
+    set2 = nscollections.MemberSet(d2)
+
+    # The sets are currently empty, ensure that this is the case.
+    assert len(set1) == 0
+    assert list(set1) == list()
+    assert not any(d in set1 for d in d1)
+
+    assert len(set2) == 0
+    assert list(set2) == list()
+    assert not any(d in set2 for d in d2)
+
+    # Add an element to the set and ensure that it can be read out.
+    set1.add(2)
+    assert 2 in set1
+    assert list(set1) == [2]
+    assert len(set1) == 1
+
+    # Adding an element that wasn't in the original domain should raise a
+    # KeyError.
+    with pytest.raises(KeyError):
+        set1.add(7)
+
+    # Testing for an element that wasn't in the original domain should raise a
+    # KeyError.
+    with pytest.raises(KeyError):
+        7 in set1
+
+    # The same for the 2nd set, has a different domain
+    set2.add(5)
+    set2.add(7)
+    assert 5 in set2
+    assert 7 in set2
+    assert list(set2) == [5, 7]
+    assert len(set2) == 2
+
+    with pytest.raises(KeyError):
+        set2.add(1)
+
+    with pytest.raises(KeyError):
+        1 in set2
+
+    # Since the domains are different various pair-wise operations should fail.
+    with pytest.raises(ValueError):
+        set1.isdisjoint(set2)
+
+
+def test_member_set_disjoint():
+    # Create two sets with the same domains
+    domain = (1, 2, 3, 4)
+    a = nscollections.MemberSet(domain)
+    b = nscollections.MemberSet(domain)
+
+    # Add different elements to each set then test various pairwise operations.
+    a.add(1)
+    b.add(2)
+
+    assert a.isdisjoint(b)
+    assert b.isdisjoint(a)
+
+    a.add(2)
+    assert not a.isdisjoint(b)
+    assert not b.isdisjoint(a)


### PR DESCRIPTION
Reduces the memory used when allocating routing keys.

Routing keys are allocated by colouring a graph whose nodes represent multicast nets and whose edges represent that their vertices may not share a routing key. For performance reasons these edges are stored as adjacency lists, but these lists became far too large to store for many useful applications. This PR switches to representing the adjacency lists with bit vectors and results is a significant memory saving. Unfortunately Python bindings for bit vectors seem to have generally poor performance.