### PR TITLE
Always use new instances of SignalParameters

### DIFF
--- a/nengo_spinnaker/builder/model.py
+++ b/nengo_spinnaker/builder/model.py
@@ -1,5 +1,6 @@
 """Objects used to represent Nengo networks as instantiated on SpiNNaker.
 """
+from copy import copy
 from collections import namedtuple, defaultdict, deque
 from nengo import LinearFilter
 import numpy as np
@@ -331,7 +332,7 @@ class ConnectionMap(object):
             # If the sink is not a passthrough node then just add the
             # connection to the new connection map.
             target_map.add_connection(
-                source, source_port, signal_pars, transmission_pars,
+                source, source_port, copy(signal_pars), transmission_pars,
                 sink_object, sink_port, reception_pars)
         else:
             # If the sink is a passthrough node then we consider each outgoing
@@ -347,7 +348,7 @@ class ConnectionMap(object):
                     if interposer is not None:
                         # Insert a connection to the interposer
                         target_map.add_connection(
-                            source, source_port, signal_pars,
+                            source, source_port, copy(signal_pars),
                             transmission_pars, interposer,
                             InputPort.standard, reception_pars
                         )

--- a/nengo_spinnaker/netlist/key_allocation.py
+++ b/nengo_spinnaker/netlist/key_allocation.py
@@ -16,6 +16,7 @@ def allocate_signal_keyspaces(signal_routes, signal_id_constraints, keyspaces):
 
     # Assign keyspaces to the signals
     for signal, i in iteritems(signal_ids):
+        assert signal.keyspace is None
         signal.keyspace = keyspaces["nengo"](connection_id=i)
 
         # Expand the keyspace to fit the required indices


### PR DESCRIPTION
Not doing so can result in the same key being overwritten leading to incorrect routing tables.