### PR TITLE
Tweaks to interposers

### DIFF
--- a/nengo_spinnaker/builder/builder.py
+++ b/nengo_spinnaker/builder/builder.py
@@ -207,7 +207,8 @@ class Model(object):
             self._build_network(network)
 
         # Insert interposers
-        interposers, connection_map = self.connection_map.insert_interposers()
+        interposers, connection_map = \
+            self.connection_map.insert_and_stack_interposers()
         self.extra_operators.extend(interposers)
         self.connection_map = connection_map
 

--- a/tests/builder/test_builder.py
+++ b/tests/builder/test_builder.py
@@ -190,7 +190,7 @@ class TestMakeConnection(object):
 
         # Modify the Model so that we can interpret calls to the connection map
         m.connection_map = mock.Mock(name="ConnectionMap")
-        m.connection_map.insert_interposers = mock.Mock(
+        m.connection_map.insert_and_stack_interposers = mock.Mock(
             return_value=([], m.connection_map)  # NOP
         )
 

--- a/tests/builder/test_transmission_parameters.py
+++ b/tests/builder/test_transmission_parameters.py
@@ -242,6 +242,72 @@ class TestTransform(object):
         # transform is empty.
         assert A.concat(B) is None
 
+    def test_hstack_two_scalars(self):
+        """Test horizontally stacking two matrices with some misaligned rows.
+        """
+        A = Transform(size_in=5, size_out=5, transform=1.0,
+                      slice_in=(0, 1), slice_out=(2, 3))
+        B = Transform(size_in=3, size_out=5, transform=0.5,
+                      slice_out=(1, 2, 3))
+
+        # Stack the transforms
+        C = A.hstack(B)
+
+        # Check the full transform is correct
+        assert np.array_equal(
+            C.full_transform(False, False),
+            np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                      [0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0],
+                      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0],
+                      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5],
+                      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]])
+        )
+
+    def test_hstack_scalar_and_vector(self):
+        """Test horizontally stacking two matrices with some misaligned rows.
+        """
+        A = Transform(size_in=5, size_out=5, transform=1.0,
+                      slice_in=(0, 1), slice_out=(2, 3))
+        B = Transform(size_in=3, size_out=5, transform=[2.0, 3.0, 4.0],
+                      slice_out=(0, 2, 3))
+
+        # Stack the transforms
+        C = A.hstack(B)
+
+        # Check the full transform is correct
+        assert np.array_equal(
+            C.full_transform(False, False),
+            np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0],
+                      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0],
+                      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4.0],
+                      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]])
+        )
+
+    def test_hstack_two_matrices(self):
+        """Test horizontally stacking two matrices with some misaligned rows.
+        """
+        transform_a = np.ones((3, 3))
+        transform_b = np.ones((2, 1)) * -1
+
+        A = Transform(size_in=4, size_out=5, transform=transform_a,
+                      slice_in=(0, 1, 2), slice_out=(2, 3, 4))
+        B = Transform(size_in=2, size_out=5, transform=transform_b,
+                      slice_in=(1, ), slice_out=(1, 2))
+
+        # Stack the transforms
+        C = A.hstack(B)
+
+        # Check the full transform is correct
+        assert np.array_equal(
+            C.full_transform(False, False),
+            np.array([[0.0, 0.0, 0.0, 0.0, 0.0,  0.0],
+                      [0.0, 0.0, 0.0, 0.0, 0.0, -1.0],
+                      [1.0, 1.0, 1.0, 0.0, 0.0, -1.0],
+                      [1.0, 1.0, 1.0, 0.0, 0.0,  0.0],
+                      [1.0, 1.0, 1.0, 0.0, 0.0,  0.0]])
+        )
+
 
 class TestPassthroughNodeTransmissionParameters(object):
     def test_concat(self):


### PR DESCRIPTION
Allow interposers to be inserted after the decoding stage of connections from ensembles and stack together interposers with the same output set to reduce network traffic.

More description + analysis to come (short story - works well :smile:)