### PR TITLE
Fix cached decoders building for recent nengo version

### DIFF
--- a/nengo_spinnaker/builder/ensemble.py
+++ b/nengo_spinnaker/builder/ensemble.py
@@ -216,9 +216,15 @@ def build_decoders(model, conn, rng):
         wrapped_solver = model.decoder_cache.wrap_solver(
             connection_b.solve_for_decoders
         )
-        decoders, solver_info = wrapped_solver(
-            conn.solver, conn.pre_obj.neuron_type, gain, bias, x, targets,
-            rng=rng, E=E)
+        try:
+            decoders, solver_info = wrapped_solver(
+                conn, gain, bias, x, targets,
+                rng=rng, E=E)
+
+        except TypeError:
+            decoders, solver_info = wrapped_solver(
+                conn.solver, conn.pre_obj.neuron_type, gain, bias, x, targets,
+                rng=rng, E=E)
     except BuildError:
         raise BuildError(
             "Building %s: 'activities' matrix is all zero for %s. "

--- a/nengo_spinnaker/builder/ensemble.py
+++ b/nengo_spinnaker/builder/ensemble.py
@@ -220,8 +220,8 @@ def build_decoders(model, conn, rng):
             decoders, solver_info = wrapped_solver(
                 conn, gain, bias, x, targets,
                 rng=rng, E=E)
-
         except TypeError:
+            # fallback for older nengo versions
             decoders, solver_info = wrapped_solver(
                 conn.solver, conn.pre_obj.neuron_type, gain, bias, x, targets,
                 rng=rng, E=E)


### PR DESCRIPTION
nengo master changed the arguments passed into the decoder cache.  

https://github.com/nengo/nengo/commit/c89434a916df7a61de17c4302a5f499d626ba1b4

This PR fixes this (and is backwards compatible)